### PR TITLE
One details page for people with orcid

### DIFF
--- a/details_page.py
+++ b/details_page.py
@@ -81,3 +81,27 @@ def search_by_orcid(search_term):
     details_alex.update(details_dblp)
     links = list(dict.fromkeys(links_alex + links_dblp))
     return details_alex, links, name
+
+
+def search_wikidata(search_term):
+    url = search_term
+    headers = {'User-Agent': 'https://nfdi-search.nliwod.org/'}
+    response = requests.get(url, headers=headers)
+
+    wikidata_id = search_term.split('/')[-1]
+    details = {}
+    links = []
+    name = ''
+
+    if response.status_code == 200:
+        data = response.json()
+        author = (data['entities'][wikidata_id])
+        name = author.get('labels').get('en').get('value')
+        details['Description'] = author.get('descriptions').get('en').get('value')
+        links.append(search_term)
+        return details, links, name
+
+    return details, links, name
+
+# dblp: P2456
+# orcid: P496

--- a/details_page.py
+++ b/details_page.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from string import Template
 
 import requests
@@ -15,22 +16,22 @@ def search_openalex(search_term: str):
     if search_term.startswith('https://orcid.org/'):
         api_url += 'authors/'
     api_url_author = requests.get(api_url + search_term)
-    if api_url_author.status_code != 404:
-        author = api_url_author.json()
-        links.append(author['id'])
-        if author['orcid']:
-            links.append(author['orcid'])
-        if 'wikipedia' in author['ids'].keys():
-            links.append(author['wikipedia'])
-        if 'twitter' in author['ids'].keys():
-            links.append(author['twitter'])
-        if author['last_known_institution']:
-            inst = author['last_known_institution']
-            details['Last known institution'] = inst['display_name'] + ' (' + inst['country_code'] + ')'
-        details['Number of works'] = author['works_count']
-        details['Number of citations'] = author['cited_by_count']
-        return details, links, author['display_name']
-    return details, links, ''
+    if api_url_author.status_code != 200:
+        return details, links, ''
+    author = api_url_author.json()
+    links.append(author['id'])
+    if author['orcid']:
+        links.append(author['orcid'])
+    if 'wikipedia' in author['ids'].keys():
+        links.append(author['wikipedia'])
+    if 'twitter' in author['ids'].keys():
+        links.append(author['twitter'])
+    if author['last_known_institution']:
+        inst = author['last_known_institution']
+        details['Last known institution'] = inst['display_name'] + ' (' + inst['country_code'] + ')'
+    details['Number of works'] = author['works_count']
+    details['Number of citations'] = author['cited_by_count']
+    return details, links, author['display_name']
 
 
 def search_dblp(search_term: str):
@@ -46,7 +47,8 @@ def search_dblp(search_term: str):
 
     details = {}
     links = []
-
+    if not ET.fromstring(response):
+        return details, links, ''
     author = ET.fromstring(response)[0]
     name = author.find('.author').text
     links.append("https://dblp.uni-trier.de/pid/" + author.find('.author').attrib['pid'])
@@ -64,7 +66,7 @@ def get_orcid(search_term):
             author = api_url_author.json()
             if author['orcid']:
                 return author['orcid']
-    if search_term.startswith('https://dblp'):
+    elif search_term.startswith('https://dblp'):
         headers = {'Accept': 'application/json'}
         response = requests.get(
             search_term + '.xml',
@@ -74,7 +76,7 @@ def get_orcid(search_term):
         for url in author.findall('.url'):
             if url.text.startswith('https://orcid.org/'):
                 return url.text
-    if search_term.startswith('http://www.wikidata'):
+    elif search_term.startswith('http://www.wikidata'):
         url = search_term
         headers = {'User-Agent': 'https://nfdi-search.nliwod.org/'}
         response = requests.get(url, headers=headers)
@@ -111,16 +113,18 @@ def search_wikidata(search_term):
 
         wikidata_id = search_term.split('/')[-1]
 
-        if response.status_code == 200:
-            data = response.json()
-            author = (data['entities'][wikidata_id])
-            name = author.get('labels').get('en').get('value')
-            if 'en' in author.get('descriptions').keys():
-                details['Description'] = author.get('descriptions').get('en').get('value')
-            links.append('https://www.wikidata.org/entity/' + wikidata_id)
+        if response.status_code != 200:
             return details, links, name
-
+        data = response.json()
+        author = (data['entities'][wikidata_id])
+        name = author.get('labels').get('en').get('value')
+        if 'en' in author.get('descriptions').keys():
+            details['Description'] = author.get('descriptions').get('en').get('value')
+        links.append('https://www.wikidata.org/entity/' + wikidata_id)
+        links_dict = author['claims']
+        links += get_wiki_links(links_dict)
         return details, links, name
+
     elif search_term.startswith('https://orcid.org/'):
         orcid = search_term.split('/')[-1]
         url = 'https://query.wikidata.org/sparql'
@@ -141,14 +145,28 @@ def search_wikidata(search_term):
                                 params={'format': 'json',
                                         'query': query_template.substitute(orcid=orcid),
                                         }, timeout=(3, 15), headers=headers)
-        if response.status_code == 200:
-            data = response.json()
-            wikidata_link = ''
-            match = data['results']['bindings']
-            if match:
-                wikidata_link = match[0]['item']['value']
-                return search_wikidata(wikidata_link)
+        if response.status_code != 200:
+            return details, links, name
+        data = response.json()
+        wikidata_link = ''
+        match = data['results']['bindings']
+        if match:
+            wikidata_link = match[0]['item']['value']
+            return search_wikidata(wikidata_link)
     return details, links, name
 
-# dblp: P2456
-# orcid: P496
+def get_wiki_links(links_dict):
+    links = []
+    headers = {'User-Agent': 'https://nfdi-search.nliwod.org/'}
+    for prop_code in links_dict.keys():
+        url = 'https://www.wikidata.org/wiki/Special:EntityData/' + prop_code
+        response = requests.get(url, headers=headers)
+        if response.status_code != 200:
+            continue
+        data = response.json()
+        claims = data['entities'][prop_code]['claims']
+        end_of_link = links_dict[prop_code][0]['mainsnak']['datavalue']['value']
+        if 'P1630' in claims.keys() and isinstance(end_of_link, str):
+            formatter_link = claims['P1630'][0]['mainsnak']['datavalue']['value']
+            links.append(formatter_link.replace('$1', end_of_link))
+    return links

--- a/main.py
+++ b/main.py
@@ -104,7 +104,8 @@ def details():
             details, links, name = details_page.search_openalex(search_term)
         elif search_term.startswith('https://dblp'):
             details, links, name = details_page.search_dblp(search_term)
-
+        elif search_term.startswith('http://www.wikidata'):
+            details, links, name = details_page.search_wikidata(search_term)
         return render_template('details.html', search_term=search_term, details=details, links=links, name=name)
 
 

--- a/main.py
+++ b/main.py
@@ -88,15 +88,23 @@ def sources():
 @app.route('/details', methods=['POST', 'GET'])
 def details():
     if request.method == 'GET':
-        # data_type = request.args.get('type')
         details = {}
         links = {}
         name = ''
         search_term = request.args.get('searchTerm')
+        if search_term.startswith('https://orcid.org/'):
+            details, links, name = details_page.search_by_orcid(search_term)
+            return render_template('details.html', search_term=search_term, details=details, links=links, name=name)
+
+        orcid = details_page.get_orcid(search_term)
+        if orcid != '':
+            return render_template('details.html', search_term=orcid, details=details, links=links, name='')
+
         if search_term.startswith('https://openalex.org/'):
             details, links, name = details_page.search_openalex(search_term)
         elif search_term.startswith('https://dblp'):
             details, links, name = details_page.search_dblp(search_term)
+
         return render_template('details.html', search_term=search_term, details=details, links=links, name=name)
 
 

--- a/templates/details.html
+++ b/templates/details.html
@@ -4,6 +4,11 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/result.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/details.css') }}">
 {% endblock %}
+{% block redirect %}
+    {% if search_term.startswith('https://orcid.org/') and name == '' %}
+        <meta http-equiv="Refresh" content="0; url='/details?searchTerm={{search_term}}'" />
+    {% endif %}
+{% endblock %}
 {% block content %}
 <div class="details_wrapper">
     <div class="header">

--- a/templates/search_layout.html
+++ b/templates/search_layout.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% block style_sheet %}{% endblock %}
+    {% block redirect %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"


### PR DESCRIPTION
Information from dblp and openalex is merged.

I've worked with redirect in html to redirect people who have an orcid to the page http://127.0.0.1:5002/details?searchTerm=https://orcid.org/... if you clicked on the dblp or the openalex link. 
I don't know if it is the best way, as you can sometimes see the page loading before it is redirected, but I hope it's okay for now.

Please review and merge if you don't see any problems.