### PR TITLE
only first 3 authors are shown on each result

### DIFF
--- a/orcid.py
+++ b/orcid.py
@@ -78,7 +78,7 @@ def search(search_term, results):
                     try:
                         display_name = name_data.get('credit-name', {}).get('value') or name_data.get('display-name', {}).get('value')
                     except AttributeError:
-                        display_name = f"{given_names}{family_name}"
+                        display_name = f"{given_names} {family_name}"
 
                     # Extract email information
                     email = json_data.get('emails', {}).get('email', [])

--- a/static/css/result.css
+++ b/static/css/result.css
@@ -2,7 +2,7 @@ html {
     --dark-gray: rgb(90, 90, 90);
     --light-gray: rgb(148, 148, 148);
     --focus-blue: rgb(69, 159, 189);
-    margin: 0;
+    margin: 5px;
 }
 
 .bsearch{
@@ -104,7 +104,21 @@ details.description:not([open]) summary::after{
     content: attr(data-open);
 }
 
+details.authors > summary {
+  list-style: none;
+}
 
+details.authors[open] summary::after{
+    display: block;
+    margin-bottom: 1em;
+    content: attr(data-open);
+}
+
+details.authors:not([open]) summary::after{
+    display: block;
+    margin-bottom: 1em;
+    content: attr(data-closed);
+}
 
 .emptySearch {
     padding-left: 90px;

--- a/templates/result.html
+++ b/templates/result.html
@@ -29,9 +29,20 @@
             <h2 class='subtitle'><a href='{{data.url}}' target='_blank'>{{data.title}}</a> </h2>
             <span style="color: gray;"> - {{data.date}}<br> {{data.description}}</span>
         </li>
-
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -42,9 +53,20 @@
             <h2 class='subtitle'><a href='{{data.url}}' target='_blank'>{{data.title}}</a> </h2>
             <span style="color: gray;"> - {{data.date}}<br> {{data.description}}</span>
         </li>
-
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -55,9 +77,20 @@
             <h2 class='subtitle'><a href='{{data.url}}' target='_blank'>{{data.title}}</a> </h2>
             <span style="color: gray;"> - {{data.date}} (Version: {{data.version}})<br> {{data.description}}</span>
         </li>
-
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -70,7 +103,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -83,7 +128,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -96,7 +153,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -109,7 +178,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -164,7 +245,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -190,7 +283,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -246,7 +351,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -259,7 +376,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -272,7 +401,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -285,7 +426,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -298,7 +451,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -311,7 +476,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -324,7 +501,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}
@@ -379,7 +568,19 @@
         </li>
 
         <div style="margin-left:10px;">
-            <p>{{data.authors}}</p>
+            {% if data.authors.count(';') == 0 %}
+                {% if data.authors.count(',') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{', '.join(data.authors.split(', ', 3)[:3])}} +{{data.authors.split(', ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% else %}
+                {% if data.authors.count(';') <= 2 %}
+                    <p>{{data.authors}}</p>
+                {% else %}
+                    <details class="authors"><summary data-closed="{{'; '.join(data.authors.split('; ', 3)[:3])}} +{{data.authors.split('; ')|length - 3}} more" data-open="{{data.authors}}"></summary></details>
+                {% endif %}
+            {% endif %}
         </div>
         {% endif %}
         {% endif %}


### PR DESCRIPTION
I've implemented the feature that only the first three authors of a article/dataset etc. are shown with the option to see the rest by clicking them.
I've also added a little bit of margin, which was requested in the last meeting.

To accomplish this I've made the necessary changes to the result.html and result.css files.

Additionally, I've fixed a minor bug, which probably doesn't belong in this branch but it was so small that I hope it is fine. I've just added a blank space between the first and last name in the orcid file. Before the names were displayed like this: RicardoUsbeck.

Please review and merge if you don't see any problems :)
