### PR TITLE
details page for people from orcid

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,6 +124,8 @@ def details():
             details, links, name = details_page.search_dblp(search_term)
         elif search_term.startswith('http://www.wikidata.org'):
             details, links, name = details_page.search_wikidata(search_term)
+        elif search_term.startswith('https://orcid.org/'):
+            details, links, name = details_page.search_orcid(search_term)
         return render_template('details.html', search_term=search_term, details=details, links=links, name=name)
 
 

--- a/orcid.py
+++ b/orcid.py
@@ -75,10 +75,7 @@ def search(search_term, results):
                     given_names = name_data.get('given-names', {}).get('value', '')
                     family_name = name_data.get('family-name', {}).get('value', '')
 
-                    try:
-                        display_name = name_data.get('credit-name', {}).get('value') or name_data.get('display-name', {}).get('value')
-                    except AttributeError:
-                        display_name = f"{given_names}{family_name}"
+                    display_name = f"{given_names} {family_name}"
 
                     # Extract email information
                     email = json_data.get('emails', {}).get('email', [])


### PR DESCRIPTION
I've implemented a basic details page for people from orcid. I've added the necessary function in details_page.py and adjusted the corresponding function in main.

I've also adjusted the name in the orcid file, because it was giving all of the variations of a name as the name of the researcher on the result page, so for example "Ricardo José De Holanda Vasconcellos; De Holanda Vasconcellos, Ricardo José; de Holanda Vasconcellos, Ricardo José; Vasconcellos, Ricardo José Holanda; Vasconcellos, R. J.H.; Vasconcellos, Ricardo J.H.; Vasconcellos, Ricardo José Holanda; Vasconcellos, Ricardo José De Holanda; Vasconcellos, Ricardo José de Holanda; De Vasconcellos, Ricardo José Holanda; de Vasconcellos, Ricardo José Holanda; Holanda Vasconcellos, Ricardo José; José De Holanda Vasconcellos, Ricardo; Vasconcellos, Ricardo Holanda; Vasconcellos, Ricardo José De Hollanda" as one name, which is a bit long. 
I've added these name variations as a detail on the details page now.

Please review and merge if you don't see any problems.