### PR TITLE
organization tab implementation and find_organization function added to GEPRIS

### DIFF
--- a/sources/gepris.py
+++ b/sources/gepris.py
@@ -2,7 +2,7 @@ import requests
 from objects import Gepris
 import logging
 from bs4 import BeautifulSoup
-from objects import Project, Person
+from objects import Project, Person, Organization
 import utils
 
 logger = logging.getLogger('nfdi_search_engine')
@@ -11,7 +11,9 @@ logger = logging.getLogger('nfdi_search_engine')
 @utils.timeit
 def search(search_term, results):
     # function call to retrive author or researchers from GEPRIS
-    find_authors(search_term, results)
+    find_author(search_term, results)
+    # function call to retrive organizations or institutions from GEPRIS
+    find_organization(search_term, results)
 
     base_url = 'https://gepris.dfg.de/gepris/OCTOPUS'
     url = f"{base_url}?context=projekt&hitsPerPage=1&index=0&keywords_criterion={search_term}&language=en&task=doSearchSimple"
@@ -88,7 +90,7 @@ def search(search_term, results):
         logger.error(f'An error occurred during the search: {e}')
 
 
-def find_authors(search_term, results):
+def find_author(search_term, results):
 
     base_url = 'https://gepris.dfg.de/gepris/OCTOPUS'
     url = f"{base_url}?context=person&hitsPerPage=1&index=0&keywords_criterion={search_term}&language=en&task=doSearchSimple"
@@ -135,11 +137,72 @@ def find_authors(search_term, results):
                 except KeyError:
                     logger.warning("Key 'href' not found in 'a' tag. Skipping project.")
                 except AttributeError:
-                    logger.warning("Unable to find project details. Skipping project.")
+                    logger.warning("Unable to find author for the search term")
         
         # logger.info(f'Got {len(results)} records from Gepris')
     
     except requests.exceptions.RequestException as e:
-        logger.error(f'Error occurred while making a request to Gepris: {e}')
+        logger.error(f'Error occurred while making a request to Gepris authors: {e}')
+    except Exception as e:
+        logger.error(f'An error occurred during the search: {e}')
+
+
+def find_organization(search_term, results):
+
+    base_url = 'https://gepris.dfg.de/gepris/OCTOPUS'
+    url = f"{base_url}?context=institution&hitsPerPage=1&index=0&keywords_criterion={search_term}&language=en&task=doSearchSimple"
+    
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Raise an exception for non-2xx status codes
+
+        logger.debug(f'Gepris response status code: {response.status_code}')
+        logger.debug(f'Gepris response headers: {response.headers}')
+    
+        soup = BeautifulSoup(response.content, 'html.parser')
+        result = soup.find("span", id="result-info")
+
+        total_reocrds = result.text
+        logger.info(f'GEPRIS - {total_reocrds} records found')
+        
+        if result:
+            url = f"{base_url}?context=institution&hitsPerPage={result.text}&index=0&keywords_criterion={search_term}&language=en&task=doSearchSimple"
+
+            response = requests.get(url)
+            response.raise_for_status()
+            
+        soup = BeautifulSoup(response.content, 'html.parser')
+        organization_list = soup.find("div", id="liste")
+        try:
+            if organization_list:
+                organizations = organization_list.find_all("div", class_=["eintrag_alternate","eintrag"])
+                
+                for organization in organizations:
+                    try:
+
+                        orgObj = Organization()
+                        orgObj.source = 'GEPRIS'
+                        orgObj.identifier = organization.find("a")["href"]
+                        orgObj.url = f'https://gepris.dfg.de{orgObj.identifier}'
+                        orgObj.name = organization.find("h2").text.strip()
+                        # Find the organizations address and retrieve text after <br> tag
+                        sub_organization = organization.find("div", class_="subInstitution")
+                        if sub_organization:
+                            orgObj.address = ','.join(sub_organization.find_all("br")[0].find_next_siblings(string=True)).strip()
+                        else:
+                            orgObj.address = " "
+
+                        results['organizations'].append(orgObj)
+                    except Exception as e:
+                        logger.warning(e)
+        except KeyError:
+            logger.warning("Key not found.")
+        except AttributeError:
+            logger.warning("Unable to find organization details")
+
+        # logger.info(f'Got {len(results)} records from Gepris')
+    
+    except requests.exceptions.RequestException as e:
+        logger.error(f'Error occurred while making a request to Gepris institutions: {e}')
     except Exception as e:
         logger.error(f'An error occurred during the search: {e}')

--- a/templates/components/organizations.html
+++ b/templates/components/organizations.html
@@ -1,0 +1,70 @@
+<table id="tbl-organizations" class="datatable display" style="width:100%">
+    <thead>
+        <tr>
+            <th>Organizations</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for organization in results.organizations %}
+        <tr>
+            <td>
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <!-- <div class="col-md-2">
+                                <img class="rounded-circle img-fluid"
+                                    src="https://st4.depositphotos.com/5226485/27394/v/1600/depositphotos_273949566-stock-illustration-creative-engineer-worker-gear-logo.jpg">
+                            </div> -->
+                            <div class="col-md-9 fs-6">
+                                <div class="row">
+                                    <div class="col-md-6 fs-5">
+                                        <a class="text-secondary fw-bold" href='#' target='#'>
+                                            {{organization.name}}</a>
+                                    </div>
+                                    <!-- <div class="col-md-6 fs-6">
+                                        <a class="text-secondary fw-bold" href='{{organization.identifier}}' target='_blank'>
+                                            ORCID: {{ organization.orcid|replace('https://orcid.org/', '') }}</a>
+                                    </div> -->
+                                </div>
+                                <div class="row px-2 pt-3">
+                                    <div class="p-2 mt-2 d-flex justify-content-between rounded text-dark"
+                                        style="background-color:rgb(218, 247, 237) ;">
+                                        <!-- <div class="d-flex flex-column">
+                                            <span class="">Designation</span>
+                                            <span class="fw-bold">Professor</span>
+                                        </div> -->
+                                        <div class="d-flex flex-column">
+                                            <span class="">Organization or Institution Address:</span>
+                                            <span class="fw-bold">{{ organization.address }}</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row px-2 pt-3">
+                                    <div class="col-lg-9 text-start">
+                                        <span class="badge bg-pill">{{organization.source}}</span>
+                                    </div>
+                                    <div class="col-lg-3 text-end">
+                                        <span class="badge bg-pill"></span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-1">
+                                <div class="row fs-5">
+                                    <!-- <div class="col-lg-12 text-end mb-3"><a target='_blank' href="#" title="bookmark"><i
+                                                    class="bi bi-bookmark"></i></a></div> -->
+                                    <div class="col-lg-12 text-end mb-3"><a target='_blank' href="#" title="Share"><i
+                                                class="bi bi-share"></i></a></div>
+                                    <div class="col-lg-12 text-end mb-3"><a target='_blank' href="#" title="Download"><i
+                                                class="bi bi-download"></i></a></div>
+
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/templates/results.html
+++ b/templates/results.html
@@ -122,7 +122,8 @@
                             {% include 'components/resources.html' %}
                         </div>
                         <div class="tab-pane fade" id="organizations" role="tabpanel"
-                            aria-labelledby="organizations-tab">...
+                            aria-labelledby="organizations-tab">
+                            {% include 'components/organizations.html' %}
                         </div>
                         <div class="tab-pane fade" id="events" role="tabpanel" aria-labelledby="events-tab">...</div>
                         <div class="tab-pane fade" id="fundings" role="tabpanel" aria-labelledby="fundings-tab">...


### PR DESCRIPTION
The new layout design's organization tab is implemented. These changes aim to have organizations' information in our system in addition to the publication, author, and resources. The following modifications have been made:

sources/gepris.py retrieve_organization function has been added to fetch relevant data from GEPRIS and incorporate it into the organization tab and mapped it based on the schema.org.
templates/components/organizations.html has been added to facilitate the organization tab's content.
templates/results.html has been updated to support the changes
I have tested the changes to ensure they are working as intended.