### PR TITLE
prevent empty search

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -10,7 +10,7 @@
             <div>
                 <div class="d-inline-block">
                     {% if search_term %}
-                    <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3" action="/results" method="GET">
+                    <form name="searchbox" class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3" action="/results" method="GET" onsubmit="return emptySearch()">
                         <!-- <input type="search" class="form-control" placeholder="Search..." aria-label="Search"> -->
                         <div>
                             <div class="searchbox">
@@ -21,6 +21,7 @@
                                 <input class="form-control" aria-label="Search for Article, Researcher"
                                     autocomplete="off" inputmode="search" placeholder="Search for Article, Researcher"
                                     type="search" name="txtSearchTerm" value="{{search_term}}" />
+                                <div class="text-secondary" id="emptySearch" style="padding-left: 50px;"></div>
                             </div>
                         </div>
                     </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <div id='mainContent' class="container">
 
         <div class="bsearch">
-            <form action="/results" method="GET">
+            <form name="searchbox" action="/results" method="GET" onsubmit="return emptySearch()">
                 <div class="">
                     <h2 class="text-center text-dark fs-1 fw-bold mb-4">Welcome to NFDI4DS Gateway</h2>
                     <div class="row mb-4">
@@ -32,9 +32,10 @@
                         </svg>
                         <input aria-label="Search for Articles and Researchers" autocomplete="off" inputmode="search"
                             placeholder="Search" type="search" name="txtSearchTerm" />
+                        <div class="text-secondary" id="emptySearch" style="padding-left: 50px;"></div>
                     </div>
                     <!--sample search terms-->
-                    <div class="d-flex justify-content-center mt-2">
+                    <div class="d-flex justify-content-center mt-4">
                         <span class="m-2">Search Tips:</span>
                         <a href="/results?txtSearchTerm=Ricardo+Usbeck" class="btn btn-success btn-sm m-2"
                             role="button">Ricardo Usbeck</a>
@@ -235,6 +236,14 @@
 {% block javascripts %}
 
 <script>
+
+    function emptySearch() {
+        var search = document.forms["searchbox"]["txtSearchTerm"].value;
+        if (search == "" || search == null || !/\S/.test(search)) {
+            document.getElementById("emptySearch").innerHTML = "\u2B11" + "Please enter a search term";
+            return false;
+        }
+    }
 
 </script>
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -205,6 +205,14 @@
 
     });
 
+    function emptySearch() {
+        var search = document.forms["searchbox"]["txtSearchTerm"].value;
+        if (search == "" || search == null || !/\S/.test(search)) {
+            document.getElementById("emptySearch").innerHTML = "\u2B11" + "Please enter a search term";
+            return false;
+        }
+    }
+
 
 
 


### PR DESCRIPTION
Searching for an empty string or just spaces doesn't work anymore. Instead, a little message appears below the searchbar to indicate that a search term should be entered.

I've changed the header.html, index.html and results.html files to accomplish that.

Please review and merge if you don't see any issues.