### PR TITLE
Updated numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ diophila~=0.4.0
 requests==2.31.0
 Wikipedia>=1.4.0
 beautifulsoup4>=2.4.1
+numpy==1.26.3
 pandas>=2.0.1
 elg~=0.5.0 # not compatible with pydantic V2
 gunicorn==20.1.0


### PR DESCRIPTION
We need to use numpy 1.xx version for now due to compatibility issues. Numpy 2.xx version is having issues with other packages.