### PR TITLE
Merging of response objects

### DIFF
--- a/config.py
+++ b/config.py
@@ -167,6 +167,21 @@ class Config:
         "settings_file_publications": "static/weights/publications-settings.json",
     }
 
+    # MAPPING_PREFERENCE is used to map the fields from the platform responses to the objects in objects.py
+    # i.e. abstracts from publications are first taken from OPENALEX - Publications, then from CROSSREF - Publications, etc.
+    MAPPING_PREFERENCE = {
+        "researchers": {
+            "__default__": ["OPENALEX - Researchers", "ORCID"],
+            "identifier": ["ORCID", "OPENALEX - Researchers"],
+        },
+        "publications": {
+            "__default__": ["CROSSREF - Publications", "OPENALEX - Publications", "OPENAIRE - Products"],
+            "abstract": ["OPENALEX - Publications", "CROSSREF - Publications", "OPENAIRE - Products"],
+            "reference": ["CROSSREF - Publications"],
+            "citation": ["CROSSREF - Publications"],
+        }
+    }
+
     # ELASTIC = {
     #     "server": os.environ.get('ELASTIC_SERVER',""),
     #     "username": os.environ.get('ELASTIC_USERNAME',""), 

--- a/main.py
+++ b/main.py
@@ -624,8 +624,10 @@ def publication_details(doi, source_id):
     if (len(publications) == 1): #forward the only publication record received from one of the sources
         response = make_response(render_template('publication-details.html', publication=publications[0]))
     else: 
-        #merge more than one publication's records from various sources into one publication
-        merged_publication = generate_response_with_openai(jsonify(publications).json)
+        # we have multiple publications
+        # we merge their fields into one publication object
+        merged_publication = merge_objects(publications, "publications")
+
         response = make_response(render_template('publication-details.html', publication=merged_publication))
 
     return response
@@ -715,7 +717,7 @@ def researcher_details(orcid, source_id):
         session['researcher:'+orcid] = jsonify(researchers[0]).json
     else: 
         #merge more than one researchers record into one researcher
-        merged_researcher = generate_response_with_openai(jsonify(researchers).json)
+        merged_researcher = merge_objects(researchers, "researchers")
         response = make_response(render_template('researcher-details.html', researcher=merged_researcher))
         session['researcher:'+orcid] = merged_researcher
 
@@ -996,7 +998,61 @@ def generate_researcher_banner(researcher_details_json):
 
 #endregion
 
+#region MISC
 
+# @utils.handle_exceptions
+def merge_objects(object_list, object_type):
+    """
+    This function revieces a list of objects defined in objects.py, and returns a new object with the merged values of the publications.
+    The preference order for merging is defined in config.py.
+    """
+
+    # the new object we create will have the type of the object in object_list which is furthest down in the inheritance hierarchy
+    # => we search for the obj with the longest __mro__
+    target_obj = max(object_list, key=lambda x: len(type(x).__mro__))
+    target_cls = type(target_obj)
+    merged_object = target_cls()
+
+    # sort object_list by mapping preference
+    mapping_pref = app.config['MAPPING_PREFERENCE'].get(object_type, {})
+
+    # get the preference list from the config for a specific field
+    # if the field is not found, returns the __defaut__ list
+    def get_field_preference(field_name):
+        return mapping_pref.get(field_name, mapping_pref.get("__default__", []))
+
+    # this function returns the index of the source in the preference list for the field
+    # it returns float('inf') if the source is not in the preference list
+    def get_preference_index(obj, field_name):
+
+        # get the name of the source of the object
+        source_list = getattr(obj, 'source', None)
+        source = source_list[0] if source_list else None
+        source_name = getattr(source, 'name', None) if source else None
+
+        # get the preference order for the field
+        pref_list = get_field_preference(field_name)
+
+        return pref_list.index(source_name) if source_name in pref_list else float('inf')
+
+    # iterate through the sorted objects and choose the first non-empty value for each field in the merged object
+    for field in fields(merged_object):
+
+        # sort the objects by the current field
+        # if the field is not found, the objects are sorted with the __default__ list
+        sorted_objects = sorted(object_list, key=lambda obj: get_preference_index(obj, field.name))
+
+        # iterate through the sorted objects until one of them contains a non-empty value for the field
+        for obj in sorted_objects:
+            val = getattr(obj, field.name, None)
+
+            if val not in (None, "", [], {}):   # check if the value is empty or a placeholder
+                setattr(merged_object, field.name, val)
+                break
+
+    return merged_object
+
+#endregion
 
 #region Control Panel
 

--- a/objects.py
+++ b/objects.py
@@ -23,6 +23,9 @@ class thing:
             # concatenate all the property values            
             strValue += f"{getattr(self, field.name)}###"
         return strValue
+    
+    def __hash__(self):
+        return hash((self.identifier, self.name, self.url, self.originalSource))
 
 @dataclass
 class Organization(thing):


### PR DESCRIPTION
Objects (i.e. publications/researchers/...) are now merged using rule-based logic instead of an openai API call. Which platforms get precedence for what fields is specified under MAPPING_PREFERENCE in config.py.