### PR TITLE
Disallow Googlebot from researcher-details and publication-details

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -52,5 +52,9 @@ Disallow: /
 User-agent: CCBot
 Disallow: /
 
+User-agent: Googlebot
+Disallow: /researcher-details/
+Disallow: /publication-details/
+
 User-agent: *
 Allow: /


### PR DESCRIPTION
We are recieving a lot of requests targeting our researcher-details pages from Googlebot IPs (66.249.68.5, 66.249.68.6, 66.249.68.7). This PR disallows the Googlebot user agent from accessing researcher-details and publication-details in the robots.txt.