### PR TITLE
fix(researchers): load ORCID-based researcher details when OpenAlex d…

### DIFF
--- a/config.py
+++ b/config.py
@@ -254,6 +254,7 @@ class Config:
             },
             "module": "orcid",
             "search-endpoint": f"https://pub.orcid.org/v3.0/expanded-search/?start=0&rows={NUMBER_OF_RECORDS_FOR_SEARCH_ENDPOINT}&q=",
+            "get-researcher-endpoint": "https://pub.orcid.org/v3.0/",
         },
         "CROSSREF - Publications": {
             "logo": {

--- a/sources/orcid.py
+++ b/sources/orcid.py
@@ -1,9 +1,60 @@
-from nfdi_search_engine.common.models.objects import Author, thing, Organization
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+from nfdi_search_engine.common.models.objects import Article, Author, Organization, thing
 from sources import data_retriever
-from typing import Iterable, Dict, Any
 from config import Config
 
 from sources.base import BaseSource
+
+_ORCID_PATH_RE = re.compile(
+    r"^(\d{4}-\d{4}-\d{4}-\d{3}[\dX])$", re.IGNORECASE
+)
+
+
+def _normalize_orcid_path(orcid: str) -> Optional[str]:
+    """Return canonical ORCID path (e.g. 0000-0002-1825-0097) or None if invalid."""
+    s = (orcid or "").strip().lower()
+    for prefix in ("https://orcid.org/", "http://orcid.org/"):
+        if s.startswith(prefix):
+            s = s[len(prefix) :]
+    s = s.strip().strip("/")
+    m = _ORCID_PATH_RE.match(s)
+    return m.group(1).upper() if m else None
+
+
+def _leaf_value(node: Any) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if isinstance(node, dict) and "value" in node:
+        v = node.get("value")
+        return str(v) if v is not None else ""
+    return str(node)
+
+
+def _doi_from_work_summary(ws: Dict[str, Any]) -> str:
+    ext = (ws.get("external-ids") or {}).get("external-id") or []
+    if isinstance(ext, dict):
+        ext = [ext]
+    for item in ext:
+        if not isinstance(item, dict):
+            continue
+        if (item.get("external-id-type") or "").lower() != "doi":
+            continue
+        val = (item.get("external-id-value") or "").strip()
+        if val:
+            return val.lower()
+    return ""
+
+
+def _as_list(x: Any) -> List[Any]:
+    if x is None:
+        return []
+    if isinstance(x, list):
+        return x
+    return [x]
 
 
 class ORCID(BaseSource):
@@ -63,6 +114,122 @@ class ORCID(BaseSource):
 
         return authorObj
 
+    def get_researcher(self, orcid: str, researchers: List[Any]) -> None:
+        """
+        Load a public ORCID record (v3.0) and map it to an Author.
+        Used when OpenAlex has no author for this ORCID but the registry does.
+        """
+        orcid_path = _normalize_orcid_path(orcid)
+        if not orcid_path:
+            return
+
+        base = Config.DATA_SOURCES[self.SOURCE].get("get-researcher-endpoint", "")
+        if not str(base).strip():
+            return
+
+        record = data_retriever.retrieve_object(
+            base_url=base,
+            identifier=f"{orcid_path}/record",
+            quote=False,
+        )
+
+        if not record or not isinstance(record, dict):
+            return
+
+        oid = record.get("orcid-identifier") or {}
+        path = _leaf_value(oid.get("path")) or orcid_path
+
+        person = record.get("person") or {}
+        name_block = person.get("name") or {}
+        given = _leaf_value(name_block.get("given-names"))
+        family = _leaf_value(name_block.get("family-name"))
+        display_name = f"{given} {family}".strip() or _leaf_value(name_block.get("credit-name"))
+
+        author = Author()
+        author.additionalType = "Person"
+        author.identifier = path
+        author.url = f"https://orcid.org/{path}"
+        author.name = display_name
+
+        for on in _as_list((person.get("other-names") or {}).get("other-name")):
+            if isinstance(on, dict):
+                c = on.get("content")
+                if isinstance(c, str) and c.strip():
+                    author.alternateName.append(c.strip())
+
+        bio = person.get("biography") or {}
+        if isinstance(bio.get("content"), str) and bio["content"].strip():
+            author.about = bio["content"].strip()
+
+        for kw in _as_list((person.get("keywords") or {}).get("keyword")):
+            if isinstance(kw, dict):
+                c = kw.get("content")
+                if isinstance(c, str) and c.strip():
+                    author.researchAreas.append(c.strip())
+
+        activities = record.get("activities-summary") or {}
+        emp_root = activities.get("employments") or {}
+        for group in _as_list(emp_root.get("affiliation-group")):
+            if not isinstance(group, dict):
+                continue
+            for item in _as_list(group.get("summaries")):
+                if not isinstance(item, dict):
+                    continue
+                es = item.get("employment-summary") or {}
+                if not isinstance(es, dict):
+                    continue
+                org = es.get("organization") or {}
+                if not isinstance(org, dict):
+                    continue
+                org_name = (org.get("name") or "").strip()
+                if not org_name:
+                    continue
+                o = Organization()
+                o.name = org_name
+                sd, ed = es.get("start-date") or {}, es.get("end-date") or {}
+                y_start = _leaf_value(sd.get("year")) if isinstance(sd, dict) else ""
+                y_end = _leaf_value(ed.get("year")) if isinstance(ed, dict) else ""
+                if y_start and y_end:
+                    o.keywords.append(f"{y_end}-{y_start}")
+                elif y_start:
+                    o.keywords.append(y_start)
+                author.affiliation.append(o)
+
+        works_root = activities.get("works") or {}
+        seen: set[str] = set()
+        for group in _as_list(works_root.get("group")):
+            if not isinstance(group, dict):
+                continue
+            summaries = _as_list(group.get("work-summary"))
+            if not summaries:
+                continue
+            ws = summaries[0]
+            if not isinstance(ws, dict):
+                continue
+            title_block = ws.get("title") or {}
+            title_obj = title_block.get("title") if isinstance(title_block, dict) else None
+            title = _leaf_value(title_obj) if title_obj is not None else ""
+            doi = _doi_from_work_summary(ws)
+            dedupe_key = doi or str(ws.get("path") or ws.get("put-code") or title)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            art = Article(
+                name=title or "(untitled)",
+                identifier=doi,
+            )
+            author.works.append(art)
+
+        author.works_count = str(len(author.works)) if author.works else ""
+
+        _source = thing()
+        _source.name = self.SOURCE
+        _source.identifier = path
+        _source.url = author.url
+        author.source.append(_source)
+
+        researchers.append(author)
+
     def search(self, search_term: str, results: dict) -> None:
         """
         Fetch json from the source, extract hits, map them to objects, and insert them in-place into the results dict.
@@ -84,3 +251,10 @@ def search(search_term: str, results, tracking=None):
     Entrypoint to search ORCID researchers.
     """
     ORCID(tracking).search(search_term, results)
+
+
+def get_researcher(orcid: str, researchers: list, tracking=None):
+    """
+    Entrypoint to load one researcher from the public ORCID record API.
+    """
+    ORCID(tracking).get_researcher(orcid, researchers)

--- a/templates/researcher-details.html
+++ b/templates/researcher-details.html
@@ -60,7 +60,7 @@
                 </div>
                 {% endif %}
                 {% if researcher.cited_by_count %}
-                <div class="summary-block p-2 ms-3"></div>
+                <div class="summary-block p-2 ms-3">
                     <i class="bi bi-chat-quote fs-4"></i>
                     <div class="fs-7 my-1">Citations</div>
                     <div class="fs-5 fw-bold">{{ researcher.cited_by_count }}</div>
@@ -115,22 +115,32 @@
                                             src="{{ url_for('static', filename='images/sources/orcid-id.png') }}"
                                             >{{researcher.orcid |replace('https://', '')}}</a>
                     </div> -->
+                    {% for s in researcher.source %}
+                    {% if s.name == 'OPENALEX - Researchers' %}
                     <div class="d-flex bd-highlight">
-                        <a href="https://openalex.org/{{researcher.source[0].identifier}}"
+                        <a href="{{ s.url or ('https://openalex.org/' ~ s.identifier) }}"
                             class="btn btn-outline-dark text-dark contact-box p-1 pe-2 mb-1" tabindex="-1" role="button"
                             aria-disabled="true"><img class="ps-1 pe-2 align-text-bottom"
-                                src="{{ url_for('static', filename='images/sources/openalex-small.png') }}">{{researcher.source[0].identifier
+                                src="{{ url_for('static', filename='images/sources/openalex-small.png') }}">{{ s.identifier
                             |replace('https://openalex.org/', '')}}</a>
                     </div>
-                    {% if researcher.source | length > 1 %}
+                    {% elif s.name == 'ORCID' %}
                     <div class="d-flex bd-highlight">
-                        <a href="{{researcher.source[1].url}}"
+                        <a href="{{ s.url or ('https://orcid.org/' ~ s.identifier) }}"
                             class="btn btn-outline-dark text-dark contact-box p-1 pe-2 mb-1" tabindex="-1" role="button"
                             aria-disabled="true"><img class="ps-1 pe-2 align-text-bottom"
-                                src="{{ url_for('static', filename='images/sources/semantic-scholar.png') }}">{{researcher.source[1].identifier
+                                src="{{ url_for('static', filename='images/sources/orcid-id.png') }}">{{ s.identifier }}</a>
+                    </div>
+                    {% elif s.url and s.name == 'SEMANTIC SCHOLAR - Researchers' %}
+                    <div class="d-flex bd-highlight">
+                        <a href="{{ s.url }}"
+                            class="btn btn-outline-dark text-dark contact-box p-1 pe-2 mb-1" tabindex="-1" role="button"
+                            aria-disabled="true"><img class="ps-1 pe-2 align-text-bottom"
+                                src="{{ url_for('static', filename='images/sources/semantic-scholar.png') }}">{{ s.identifier
                             |replace('https://', '')}}</a>
                     </div>
                     {% endif %}
+                    {% endfor %}
                     <!-- <div class="d-flex bd-highlight">
                         <a href="#" class="btn btn-outline-dark text-dark contact-box p-1 pe-2 mb-1" tabindex="-1"
                             role="button" aria-disabled="true"><i class="ps-1 pe-2 fs-5 bi-twitter"></i>@albertocorona</a>


### PR DESCRIPTION
## Summary
Fixes an issue where researcher detail pages failed for ORCID-only profiles, showing a fallback message even when valid ORCID records exist.

## Root cause
Researcher details were only resolved through sources exposing a `get-researcher-endpoint` (primarily OpenAlex). ORCID search results were not mapped to a researcher detail retrieval function, causing empty results for valid ORCID IDs.

## Changes
- Added ORCID `get-researcher-endpoint` in configuration
- Implemented `get_researcher` in ORCID source using ORCID v3.0 public record API
- Updated researcher-details template to properly render multi-source profiles (OpenAlex, ORCID, Semantic Scholar)
- Fixed HTML rendering issue in citations summary block
- Removed assumption that `source[0]` always represents OpenAlex

## Impact
- Researcher details now correctly resolve for ORCID-only profiles
- Multi-source researcher entries are rendered consistently
- Improved robustness of researcher detail aggregation logic across heterogeneous data providers