### PR TITLE
Celery Integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import logging
 import logging.config
+import tempfile
+import threading
 
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -17,6 +19,7 @@ from nfdi_search_engine.infra.elastic.indices import ensure_indices
 from nfdi_search_engine.infra.store.in_memory_result_store import InMemoryTTLResultStore
 from nfdi_search_engine.infra.store.in_memory_kv_store import InMemoryTTLKVStore
 from nfdi_search_engine.infra.jobs.inprocess_dispatcher import InProcessDispatcher
+from nfdi_search_engine.infra.jobs.celery_app import celery_app
 from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
 from nfdi_search_engine.infra.jobs.chatbot_processor import ChatbotProcessor
 from nfdi_search_engine.services.user_service import UserService
@@ -174,5 +177,22 @@ def create_app() -> Flask:
     app.register_blueprint(account_bp)
     app.register_blueprint(chatbot_bp)
     app.register_blueprint(details_bp)
+
+    # start celery worker and beat threads
+    celery_app.conf.update(
+        beat_schedule=Config.JOBS["beat_schedule"],
+        include=Config.JOBS["include"],
+        beat_schedule_filename=os.path.join(tempfile.gettempdir(), "celerybeat-schedule"),
+    )
+    threading.Thread(
+        target=lambda: celery_app.Worker(loglevel="WARNING", pool="solo", concurrency=1, quiet=True).start(),
+        daemon=True,
+        name="celery-worker",
+    ).start()
+    threading.Thread(
+        target=lambda: celery_app.Beat(loglevel="WARNING", quiet=True).run(),
+        daemon=True,
+        name="celery-beat",
+    ).start()
 
     return app

--- a/config.py
+++ b/config.py
@@ -488,6 +488,20 @@ class Config:
         },
     }
 
+    JOBS = {
+        "beat_schedule": {
+            # scheduled jobs go here. Example:
+            # "hello-world-every-10s": {
+            #     "task": "nfdi_search_engine.infra.jobs.scheduled.hello_world.run",
+            #     "schedule": 10.0,
+            # }
+        },
+        "include": [
+            # add the module path of each task file here. Example:
+            # "nfdi_search_engine.infra.jobs.scheduled.hello_world"
+        ],
+    }
+
     ELASTIC = {
         "server": app_settings.ELASTIC_SERVER,
         "username": app_settings.ELASTIC_USERNAME,

--- a/nfdi_search_engine/infra/jobs/celery_app.py
+++ b/nfdi_search_engine/infra/jobs/celery_app.py
@@ -1,0 +1,17 @@
+import logging
+
+from celery import Celery
+from celery.signals import task_prerun
+
+log = logging.getLogger(__name__)
+
+celery_app = Celery(
+    "nfdi",
+    broker="memory://",
+    backend="cache+memory://",
+)
+
+# print a log message whenever a task starts
+@task_prerun.connect
+def _on_task_start(task_id, task, *args, **kwargs):
+    log.info("Job started: %s (id=%s)", task.name, task_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ email-validator==2.2.0
 Flask-Limiter==3.12
 pydantic==2.11.7
 pydantic-settings==2.12.0
+celery==5.6.3


### PR DESCRIPTION
This PR adds the [celery package](https://docs.celeryq.dev/en/stable/index.html) to allow scheduled jobs. Notes:

- Jobs can be defined in `config.py` under `JOBS`
- Job implementations go in `nfdi_search_engine/infra/jobs/scheduled/` as individual Python files with a `@celery_app.task` decorated function
- Jobs are saved in-memory (see `nfdi_search_engine/infra/jobs/celery_app.py`), but this can be expanded to use Redis or similar
- When running locally (via `python main.py`), you may see jobs launched twice. This is caused by Flasks Werkzeug reloader spawning two processes, which each create their own celery object. Running it in Docker is fine though, gunicorn launches only one process