### PR TITLE
Fix resource-details flow for OpenAIRE, Zenodo, and Resodate

### DIFF
--- a/config.py
+++ b/config.py
@@ -174,6 +174,7 @@ class Config:
             "module": "zenodo",
             "search-endpoint": f"https://zenodo.org/api/records?size=25&q=",
             "get-publication-endpoint": f"https://zenodo.org/api/records/",
+            "get-resource-endpoint": f"https://zenodo.org/api/records/",
         },
         "WIKIDATA - Publications": {
             "logo": {
@@ -232,6 +233,7 @@ class Config:
             "module": "openaire_products",
             "search-endpoint": f"https://api.openaire.eu/search/researchProducts?format=json&size={NUMBER_OF_RECORDS_FOR_SEARCH_ENDPOINT}&keywords=",
             "get-publication-endpoint": f"https://api.openaire.eu/search/researchProducts?format=json&doi=",
+            "get-resource-endpoint": f"https://api.openaire.eu/graph/v2/researchProducts/",
         },
         "OPENAIRE - Projects": {
             "logo": {

--- a/nfdi_search_engine/services/resource_details_service.py
+++ b/nfdi_search_engine/services/resource_details_service.py
@@ -36,10 +36,29 @@ class ResourceDetailsService:
         """
         mod = None
         try:
-            mod_name = self.settings.data_sources[source_name].get(
+            source_cfg = self.settings.data_sources.get(source_name)
+            if not source_cfg:
+                self.tracking.log_event_async(
+                    log_type="warning",
+                    method="get_resource_details",
+                    args=[source_name, doi],
+                    message=f"resource source not configured: {source_name}",
+                )
+                return None
+
+            mod_name = source_cfg.get(
                 "module", ""
             )
             mod = importlib.import_module(f"sources.{mod_name}")
+            if not hasattr(mod, "get_resource"):
+                self.tracking.log_event_async(
+                    log_type="warning",
+                    filename=getattr(mod, "__file__", mod_name),
+                    method="get_resource_details",
+                    args=[source_name, doi],
+                    message=f"resource details not supported for source: {source_name}",
+                )
+                return None
             return mod.get_resource(doi, tracking=self.tracking)
         except Exception as e:
             self.tracking.log_event_async(

--- a/sources/openaire_products.py
+++ b/sources/openaire_products.py
@@ -2,6 +2,7 @@ from nfdi_search_engine.common.models.objects import thing, Article, Author, Cre
 from sources import data_retriever
 from config import Config
 from typing import Union, Iterable, Dict, Any
+from urllib.parse import quote
 
 from sources.base import BaseSource
 from nfdi_search_engine.common.formatting import remove_html_tags
@@ -205,6 +206,86 @@ class OpenAIRE_Products(BaseSource):
 
         return None
 
+    def get_resource(self, identifier: str):
+        """
+        Retrieve detailed information for a single OpenAIRE resource.
+        Uses OpenAIRE Graph API by OpenAIRE id.
+        """
+        endpoint = Config.DATA_SOURCES[self.SOURCE].get('get-resource-endpoint', '')
+        if not endpoint:
+            self.log_event(type="error", message=f"{self.SOURCE} - get-resource-endpoint is missing")
+            return None
+
+        graph_item = data_retriever.retrieve_data(
+            base_url="",
+            search_term="",
+            url=f"{endpoint}{quote(identifier, safe='')}",
+            quote=False,
+        )
+
+        resource_type = str(graph_item.get("type", "")).upper()
+        if resource_type not in ["DATASET", "SOFTWARE"]:
+            self.log_event(
+                type="error",
+                message=f"{self.SOURCE} - detail record is not a resource type: {resource_type}",
+            )
+            return None
+
+        digital_obj = Dataset() if resource_type == "DATASET" else SoftwareApplication()
+        digital_obj.additionalType = resource_type
+
+        # prefer DOI pid as canonical identifier, fallback to OpenAIRE id
+        pids = graph_item.get("pids", []) or []
+        doi_pid = next((p.get("value", "") for p in pids if str(p.get("scheme", "")).lower() == "doi"), "")
+        digital_obj.identifier = doi_pid or graph_item.get("id", "")
+        digital_obj.name = graph_item.get("mainTitle", "")
+
+        descriptions = graph_item.get("descriptions", []) or []
+        if descriptions:
+            digital_obj.description = remove_html_tags(str(descriptions[0]))
+            digital_obj.abstract = digital_obj.description
+
+        digital_obj.datePublished = graph_item.get("publicationDate", "")
+        digital_obj.license = (graph_item.get("bestAccessRight", {}) or {}).get("label", "")
+
+        language = graph_item.get("language")
+        if language:
+            if isinstance(language, str):
+                digital_obj.inLanguage.append(language)
+            elif isinstance(language, dict):
+                lang_val = language.get("value") or language.get("label") or language.get("code")
+                if lang_val:
+                    digital_obj.inLanguage.append(lang_val)
+
+        for subj in (graph_item.get("subjects", []) or []):
+            value = (subj.get("subject", {}) or {}).get("value", "")
+            if value:
+                digital_obj.keywords.append(value)
+
+        for a in (graph_item.get("authors", []) or []):
+            person = Author()
+            person.additionalType = "Person"
+            person.name = a.get("fullName", "") or " ".join(filter(None, [a.get("name", ""), a.get("surname", "")])).strip()
+            pid = a.get("pid", {}) or {}
+            person.identifier = (pid.get("id", {}) or {}).get("value", "")
+            if person.name:
+                digital_obj.author.append(person)
+
+        urls = []
+        for inst in (graph_item.get("instances", []) or []):
+            urls.extend(inst.get("urls", []) or [])
+        if urls:
+            digital_obj.url = urls[0]
+
+        src = thing()
+        src.name = self.SOURCE
+        src.identifier = graph_item.get("id", identifier)
+        src.url = digital_obj.url
+        digital_obj.source.append(src)
+
+        self.log_event(type="info", message=f"{self.SOURCE} - retrieved resource details")
+        return digital_obj
+
 
 def search(search_term: str, results: dict, tracking=None):
     """
@@ -219,3 +300,7 @@ def get_publication(doi, publications, tracking=None) -> None:
 
     if publication:
         publications.append(publication)
+
+
+def get_resource(doi: str, tracking=None):
+    return OpenAIRE_Products(tracking).get_resource(doi)

--- a/sources/resodate.py
+++ b/sources/resodate.py
@@ -267,7 +267,7 @@ class Resodate(BaseSource):
             "size": 1,
             "query": {
                 "ids": {
-                    "values": [self.SOURCE],
+                    "values": [doi],
                 }
             },
         }

--- a/sources/zenodo.py
+++ b/sources/zenodo.py
@@ -54,11 +54,12 @@ class ZENODO(BaseSource):
             digitalObj = CreativeWork()
 
         digitalObj.additionalType = resource_type
-        digitalObj.identifier = hit.get('doi', '')
-        digitalObj.name = hit.get('title', '')
+        digitalObj.identifier = hit.get('doi', '') or metadata.get('doi', '')
+        digitalObj.name = hit.get('title', '') or metadata.get('title', '')
         digitalObj.url = hit.get('links', {}).get('self', '')
 
         digitalObj.description = remove_html_tags(metadata.get('description', ''))
+        digitalObj.abstract = digitalObj.description
 
         keywords = metadata.get('keywords', [])
         if isinstance(keywords, list):
@@ -92,8 +93,6 @@ class ZENODO(BaseSource):
         digitalObj.source.append(_source)
 
         if resource_type.upper() == 'PUBLICATION':
-            digitalObj.abstract = digitalObj.description
-
             files = hit.get('files', [])
             for file in files:
                 if file.get("key", "").endswith(".pdf"):
@@ -116,6 +115,35 @@ class ZENODO(BaseSource):
             else: # 'PRESENTATION', 'POSTER', 'VIDEO', 'IMAGE', 'LESSON', OTHERS
                 results['others'].append(digitalObj)
 
+    def get_resource(self, identifier: str) -> Union[CreativeWork, Dataset, SoftwareApplication, None]:
+        """
+        Retrieve detailed information for a single Zenodo resource.
+        The identifier is the Zenodo record id from source metadata.
+        """
+        search_result = data_retriever.retrieve_object(
+            base_url=Config.DATA_SOURCES[self.SOURCE].get('get-resource-endpoint', ''),
+            identifier=identifier,
+            quote=False,
+        )
+        if not search_result:
+            self.log_event(type="error", message=f"{self.SOURCE} - failed to retrieve resource details")
+            return None
+
+        digital_obj = self.map_hit(search_result)
+        if digital_obj.additionalType.upper() in ['DATASET', 'SOFTWARE']:
+            self.log_event(type="info", message=f"{self.SOURCE} - retrieved resource details")
+            return digital_obj
+
+        self.log_event(
+            type="error",
+            message=f"{self.SOURCE} - detail record is not a resource type: {digital_obj.additionalType}",
+        )
+        return None
+
 
 def search(search_term: str, results: dict, tracking=None):
     ZENODO(tracking).search(search_term, results)
+
+
+def get_resource(doi: str, tracking=None) -> Union[CreativeWork, Dataset, SoftwareApplication, None]:
+    return ZENODO(tracking).get_resource(doi)

--- a/templates/partials/search-results/resource-block.html
+++ b/templates/partials/search-results/resource-block.html
@@ -6,22 +6,25 @@
         <div class="col-11 fs-6">
             <div class="row mb-2">
                 <div class="col-9 fs-6">
-                    {% if resource.identifier == '' %}
+                    {% set resource_detail_path = resource | format_digital_obj_url('source-name','source-id') %}
+                    {% if resource.identifier == '' or 'source-id:na' in resource_detail_path %}
                     <span class="text-secondary fw-bold">
                         {{resource.name}}</span>
                     {% else %}
                     <a class="text-secondary fw-bold"
-                        href="/resource-details/{{resource | format_digital_obj_url('source-name','doi')}}"
+                        href="/resource-details/{{resource_detail_path}}"
                         target='_blank'><i class="pull-left bi bi-link-45deg"></i>&nbsp;{{resource.name}}</a>
                     {% endif %}
                 </div>
                 <div class="col-3 text-end">
-                    {% for source in resource.source %}
+                    {% for source in (resource.source or []) %}
+                    {% if source.url %}
                     <a id="source_link" href="{{source.url}}" target=_blank>
                         <span class="badge bg-pill text-wrap text-break">
                             <span class="source_name">{{source.name}}</span>
                             &nbsp;<i class="pull-right bi bi-box-arrow-up-right"></i></span>
                     </a>
+                    {% endif %}
                     <span class="badge bg-pill bg-secondary text-wrap text-break visually-hidden source_identifier"
                         data-bs-toggle="tooltip" data-bs-placement="top"
                         title="ID in source system">{{source.identifier}}</span>
@@ -37,7 +40,7 @@
             <div class="row">
                 <div class="col-12 my-2 authors">
                     {% set author_count = namespace(value=0) %}
-                    {% for author in resource.author %}
+                    {% for author in (resource.author or []) %}
                     {% if author_count.value == 5 %}
                     <a href="#" class="tag_more_authors">and {{ (resource.author|count) - 5 }}
                         more</a>
@@ -68,7 +71,7 @@
                         data-bs-placement="top" title="Source">{{resource.originalSource}}</span>
                     <span class="badge bg-pill bg-secondary text-wrap text-break" data-bs-toggle="tooltip"
                         data-bs-placement="top" title="Type">{{resource.additionalType}}</span>
-                    {% for language in resource.inLanguage %}
+                    {% for language in (resource.inLanguage or []) %}
                     <span class="badge bg-pill bg-secondary text-wrap text-break" data-bs-toggle="tooltip"
                         data-bs-placement="top" title="Language">{{language|upper}}</span>
                     {% endfor %}
@@ -109,7 +112,7 @@
         {% with share_modal_id='share-resource-'+resource.identifier | regex_replace ('\W',''),
         preview_modal_id='preview-resource-'+resource.identifier | regex_replace ('\W',''),
         download_modal_id='download-resource-'+resource.identifier | regex_replace ('\W',''),
-        url = '/resource-details/'+ resource | format_digital_obj_url('doi','source-name'),
+        url = '/resource-details/'+ resource | format_digital_obj_url('source-name','source-id'),
         img_src = resource.image,
         encoding_contentUrl = resource.encoding_contentUrl,
         title = resource.name | trim


### PR DESCRIPTION
### Summary
- fix resource-details retrieval for previously failing sources: `sources/openaire_products.py`, `sources/zenodo.py`, and `sources/resodate.py`
- align resource detail routing/ID mapping to use source-specific resource identifiers from search results
- add/adjust source detail endpoints and parsing so details load consistently, with graceful fallback when details are unavailable
- harden service/template behavior for missing or unsupported resource-detail fields (`nfdi_search_engine/services/resource_details_service.py`, `templates/partials/search-results/resource-block.html`, `config.py`)
