### PR TITLE
OpenTelemetry Tracing Instrumentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from nfdi_search_engine.web.errors import register_error_handlers
 from nfdi_search_engine.web.auth.login import init_login_loader
 from nfdi_search_engine.infra.elastic.client import get_es_client
 from nfdi_search_engine.infra.elastic.indices import ensure_indices
+from nfdi_search_engine.infra.observability.init import init_tracing, TracingConfig
 from nfdi_search_engine.infra.store.in_memory_result_store import InMemoryTTLResultStore
 from nfdi_search_engine.infra.store.in_memory_kv_store import InMemoryTTLKVStore
 from nfdi_search_engine.infra.jobs.inprocess_dispatcher import InProcessDispatcher
@@ -163,6 +164,10 @@ def create_app() -> Flask:
 
     # register user loader
     init_login_loader()
+
+    # initialize tracing
+    tracing_conf = TracingConfig.from_config(app.config)
+    init_tracing(app, tracing_conf)
 
     # register blueprints
     from nfdi_search_engine.web.public import bp as public_bp

--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     CHATBOT_SERVER: str = Field(default="https://nfdi-chatbot.nliwod.org")
 
     # OpenTelemetry tracing
-    TRACING_ENABLED: bool = False
+    TRACING_ENABLED: bool = True
     TRACING_SERVICE_NAME: str = "nfdi-search-engine"
     TRACING_OTLP_ENDPOINT: str = "http://jaeger:4317"
     TRACING_OTLP_PROTOCOL: str = "grpc"  # "grpc" | "http/protobuf"

--- a/config.py
+++ b/config.py
@@ -1,8 +1,8 @@
 import os
 from dotenv import find_dotenv, load_dotenv
 
-from typing import Optional, Dict, Any
-from pydantic import Field, HttpUrl, ValidationError
+from typing import Optional
+from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # load environment variables
@@ -42,6 +42,16 @@ class Settings(BaseSettings):
     ELASTIC_USERNAME: str = Field(default="elastic")
     ELASTIC_PASSWORD: Optional[str] = None
     CHATBOT_SERVER: str = Field(default="https://nfdi-chatbot.nliwod.org")
+
+    # OpenTelemetry tracing
+    TRACING_ENABLED: bool = False
+    TRACING_SERVICE_NAME: str = "nfdi-search-engine"
+    TRACING_OTLP_ENDPOINT: str = "http://jaeger:4317"
+    TRACING_OTLP_PROTOCOL: str = "grpc"  # "grpc" | "http/protobuf"
+    TRACING_SAMPLER: str = "always_on"   # "always_on" | "always_off" | "traceidratio" | "parentbased_traceidratio"
+    TRACING_SAMPLER_ARG: Optional[float] = None
+    TRACING_INSTRUMENT_FLASK: bool = True
+    TRACING_INSTRUMENT_REQUESTS: bool = True
 
     model_config = SettingsConfigDict(env_file=find_dotenv(), env_file_encoding='utf-8', extra='ignore')
 
@@ -100,6 +110,15 @@ class Config:
         ELASTIC_USERNAME = app_settings.ELASTIC_USERNAME
         ELASTIC_PASSWORD = app_settings.ELASTIC_PASSWORD
         CHATBOT_SERVER = app_settings.CHATBOT_SERVER
+
+        TRACING_ENABLED = app_settings.TRACING_ENABLED
+        TRACING_SERVICE_NAME = app_settings.TRACING_SERVICE_NAME
+        TRACING_OTLP_ENDPOINT = app_settings.TRACING_OTLP_ENDPOINT
+        TRACING_OTLP_PROTOCOL = app_settings.TRACING_OTLP_PROTOCOL
+        TRACING_SAMPLER = app_settings.TRACING_SAMPLER
+        TRACING_SAMPLER_ARG = app_settings.TRACING_SAMPLER_ARG
+        TRACING_INSTRUMENT_FLASK = app_settings.TRACING_INSTRUMENT_FLASK
+        TRACING_INSTRUMENT_REQUESTS = app_settings.TRACING_INSTRUMENT_REQUESTS
 
     SESSION_PERMANENT = False
     SESSION_TYPE = "filesystem"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,33 @@
+services:
+  search-engine:
+    ports:
+      - "6001:8000"
+    depends_on:
+      elastic:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy
+
+  jaeger:
+    depends_on:
+      elastic:
+        condition: service_healthy
+
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+        - nfdi-search-engine_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,15 @@ services:
         ports:
             - 6000:8000
         restart: unless-stopped
+        depends_on:
+            - jaeger
+        networks:
+            - nfdi-search-engine_default
+
+    jaeger:
+        image: cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+        ports:
+            - 16686:16686
         networks:
             - nfdi-search-engine_default
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,25 @@ services:
             - 6000:8000
         restart: unless-stopped
         depends_on:
-            - jaeger
+            jaeger:
+                condition: service_healthy
         networks:
             - nfdi-search-engine_default
 
     jaeger:
         image: cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+        command: ["--config", "/etc/jaeger/config.yaml"]
+        volumes:
+            - ./jaeger-config.yaml:/etc/jaeger/config.yaml:ro
+        environment:
+            JAEGER_ES_SERVER_URLS: "${ELASTIC_SERVER}"
+            JAEGER_ES_USERNAME: "${ELASTIC_USERNAME}"
+            JAEGER_ES_PASSWORD: "${ELASTIC_PASSWORD}"
+        healthcheck:
+            test: ["CMD-SHELL", "wget -qO- http://localhost:13133/health/status >/dev/null || exit 1"]
+            interval: 10s
+            timeout: 3s
+            retries: 10
         ports:
             - 16686:16686
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             JAEGER_ES_SERVER_URLS: "${ELASTIC_SERVER}"
             JAEGER_ES_USERNAME: "${ELASTIC_USERNAME}"
             JAEGER_ES_PASSWORD: "${ELASTIC_PASSWORD}"
+        restart: unless-stopped
         healthcheck:
             test: ["CMD-SHELL", "wget -qO- http://localhost:13133/health/status >/dev/null || exit 1"]
             interval: 10s

--- a/jaeger-config.yaml
+++ b/jaeger-config.yaml
@@ -1,0 +1,77 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+extensions:
+  healthcheckv2:
+    use_v2: true
+    http:
+      endpoint: "0.0.0.0:13133"
+      status:
+        enabled: true
+        path: "/health/status"
+  jaeger_storage:
+    backends:
+      es:
+        elasticsearch:
+          server_urls:
+            - "${env:JAEGER_ES_SERVER_URLS}"
+
+          auth:
+            basic:
+              username: "${env:JAEGER_ES_USERNAME}"
+              password: "${env:JAEGER_ES_PASSWORD}"
+
+          indices:
+            index_prefix: "jaeger-main"
+
+            spans:
+              date_layout: "2006-01-02"
+              rollover_frequency: "week"
+              shards: 1
+              replicas: 0
+
+            services:
+              date_layout: "2006-01-02"
+              rollover_frequency: "week"
+              shards: 1
+              replicas: 0
+
+            dependencies:
+              date_layout: "2006-01-02"
+              rollover_frequency: "week"
+              shards: 1
+              replicas: 0
+
+            sampling:
+              date_layout: "2006-01-02"
+              rollover_frequency: "week"
+              shards: 1
+              replicas: 0
+
+  jaeger_query:
+    storage:
+      traces: es
+    http:
+      endpoint: 0.0.0.0:16686
+    grpc:
+      endpoint: 0.0.0.0:16685
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: es
+
+service:
+  extensions: [healthcheckv2, jaeger_storage, jaeger_query]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter]

--- a/nfdi_search_engine/infra/observability/config.py
+++ b/nfdi_search_engine/infra/observability/config.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any, Literal
+
+OtlpProtocol = Literal[
+    "grpc",
+    "http/protobuf"
+]
+
+SamplerName = Literal[
+    "always_on",
+    "always_off",
+    "traceidratio",
+    "parentbased_traceidratio"
+]
+
+
+@dataclass(frozen=True)
+class TracingConfig:
+    """
+    Configuration for OpenTelemetry tracing initialization.
+
+    :param enabled: Global on/off switch. If False, a NoOp tracer provider is installed.
+    :type enabled: bool
+    :param service_name: OTel resource service name ("service.name").
+    :type service_name: str
+    :param otlp_endpoint: OTLP exporter endpoint, e.g. "otel-collector:4317" (gRPC) or "http://otel-collector:4318" (HTTP).
+    :type otlp_endpoint: str
+    :param otlp_protocol: OTLP protocol ("grpc" or "http/protobuf").
+    :type otlp_protocol: OtlpProtocol
+    :param traces_sampler: Sampling strategy.
+    :type traces_sampler: SamplerName
+    :param traces_sampler_arg: Ratio for ratio-based samplers (e.g. 0.05 for 5%).
+    :type traces_sampler_arg: Optional[float]
+    :param instrument_flask: Enable Flask auto-instrumentation.
+    :type instrument_flask: bool
+    :param instrument_requests: Enable requests auto-instrumentation.
+    :type instrument_requests: bool
+    """
+    enabled: bool
+    service_name: str = "nfdi-search-engine"
+    otlp_endpoint: str = "otel-collector:4317"
+    otlp_protocol: OtlpProtocol = "grpc"
+    traces_sampler: SamplerName = "always_on"
+    traces_sampler_arg: Optional[float] = None
+    instrument_flask: bool = True
+    instrument_requests: bool = True
+
+    @classmethod
+    def from_config(cls, cfg: Dict[str, Any]) -> "TracingConfig":
+        return cls(
+            enabled=bool(cfg.get("TRACING_ENABLED", False)),
+            service_name=str(cfg.get(
+                "TRACING_SERVICE_NAME",
+                "nfdi-search-engine"
+            )),
+            otlp_endpoint=str(cfg.get(
+                "TRACING_OTLP_ENDPOINT",
+                "otel-collector:4317"
+            )),
+            otlp_protocol=cfg.get("TRACING_OTLP_PROTOCOL", "grpc"),
+            traces_sampler=cfg.get("TRACING_SAMPLER", "always_on"),
+            traces_sampler_arg=(
+                float(cfg["TRACING_SAMPLER_ARG"])
+                if cfg.get("TRACING_SAMPLER_ARG") is not None else None
+            ),
+            instrument_flask=bool(cfg.get("TRACING_INSTRUMENT_FLASK", True)),
+            instrument_requests=bool(cfg.get(
+                "TRACING_INSTRUMENT_REQUESTS",
+                True
+            )),
+        )

--- a/nfdi_search_engine/infra/observability/context.py
+++ b/nfdi_search_engine/infra/observability/context.py
@@ -1,0 +1,12 @@
+from opentelemetry import context as otel_context
+
+
+def with_parent_context(fn):
+    parent_ctx = otel_context.get_current()
+    def wrapped(*args, **kwargs):
+        token = otel_context.attach(parent_ctx)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            otel_context.detach(token)
+    return wrapped

--- a/nfdi_search_engine/infra/observability/decorators.py
+++ b/nfdi_search_engine/infra/observability/decorators.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
+tracer = trace.get_tracer("nfdi_search_engine")
+
+
+def traced(
+    name: Optional[str] = None,
+    *,
+    attrs: Optional[Callable[..., dict[str, Any]]] = None,
+):
+    """
+    Decorator to create an OpenTelemetry span around a function.
+
+    - name: span name (defaults to qualname)
+    - attrs: optional callback that returns span attributes from *args/**kwargs
+    """
+    def deco(fn: Callable[..., Any]):
+        span_name = name or fn.__qualname__
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with tracer.start_as_current_span(span_name) as span:
+                if attrs:
+                    try:
+                        for k, v in (attrs(*args, **kwargs) or {}).items():
+                            if v is not None:
+                                span.set_attribute(k, v)
+                    except Exception:
+                        # never fail the request because of tracing
+                        pass
+                try:
+                    return fn(*args, **kwargs)
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR, str(e)))
+                    raise
+        return wrapper
+    return deco

--- a/nfdi_search_engine/infra/observability/init.py
+++ b/nfdi_search_engine/infra/observability/init.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from opentelemetry import trace
+from opentelemetry.trace import NoOpTracerProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF, ALWAYS_ON, TraceIdRatioBased, ParentBased
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as OTLPGrpcSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as OTLPHttpSpanExporter
+
+from nfdi_search_engine.infra.observability.config import TracingConfig
+
+
+def init_tracing(app, cfg: TracingConfig) -> None:
+    """
+    Configure OpenTelemetry tracing for the Flask app.
+    """
+    # prevents double initialization, e.g. during testing later
+    if getattr(app, "_otel_initialized", False):
+        return
+
+    if not cfg.enabled:
+        trace.set_tracer_provider(NoOpTracerProvider())
+        app._otel_initialized = True
+        return
+
+    if cfg.traces_sampler == "always_off":
+        sampler = ALWAYS_OFF
+    elif cfg.traces_sampler == "always_on":
+        sampler = ALWAYS_ON
+    elif cfg.traces_sampler in {"traceidratio", "parentbased_traceidratio"}:
+        ratio = cfg.traces_sampler_arg if cfg.traces_sampler_arg is not None else 0.05
+        base = TraceIdRatioBased(ratio)
+        sampler = ParentBased(
+            base) if cfg.traces_sampler == "parentbased_traceidratio" else base
+    else:
+        sampler = ALWAYS_ON
+
+    resource = Resource.create({"service.name": cfg.service_name})
+    provider = TracerProvider(resource=resource, sampler=sampler)
+    trace.set_tracer_provider(provider)
+
+    if cfg.otlp_protocol == "http/protobuf":
+        exporter = OTLPHttpSpanExporter(endpoint=cfg.otlp_endpoint)
+    else:
+        exporter = OTLPGrpcSpanExporter(endpoint=cfg.otlp_endpoint)
+
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    if cfg.instrument_flask:
+        from opentelemetry.instrumentation.flask import FlaskInstrumentor
+        FlaskInstrumentor().instrument_app(app)
+
+    if cfg.instrument_requests:
+        from opentelemetry.instrumentation.requests import RequestsInstrumentor
+        RequestsInstrumentor().instrument()
+
+    app._otel_initialized = True

--- a/nfdi_search_engine/services/deduplication/service.py
+++ b/nfdi_search_engine/services/deduplication/service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from nfdi_search_engine.services.deduplication.merger import ObjectMerger
 from nfdi_search_engine.services.deduplication.policies.base import DedupPolicy
+from nfdi_search_engine.infra.observability.decorators import traced
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,13 @@ class DeduplicationService:
         self.mapping_preference = mapping_preference
         self.merger = ObjectMerger()
 
+    @traced(
+        "deduplication_service.deduplicate",
+        attrs=lambda self, results: {
+            "policies.count": len(self.policies),
+            "results.category_count": len(results)
+        }
+    )
     def deduplicate(self, results: dict) -> dict:
         """Deduplicate search results according to the policies."""
         for policy in self.policies:

--- a/nfdi_search_engine/services/deduplication/service.py
+++ b/nfdi_search_engine/services/deduplication/service.py
@@ -27,7 +27,8 @@ class DeduplicationService:
         "deduplication_service.deduplicate",
         attrs=lambda self, results: {
             "policies.count": len(self.policies),
-            "results.category_count": len(results)
+            "results.category_count": len(results),
+            "results.total_value_count": sum(len(c) for c in results.values()),
         }
     )
     def deduplicate(self, results: dict) -> dict:

--- a/nfdi_search_engine/services/publication_details_service.py
+++ b/nfdi_search_engine/services/publication_details_service.py
@@ -11,6 +11,7 @@ from nfdi_search_engine.common.models.objects import Article
 from nfdi_search_engine.common.models.details_settings import DetailsSettings
 from nfdi_search_engine.services.tracking_service import TrackingService
 from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+from nfdi_search_engine.infra.observability.decorators import traced
 
 
 class PublicationDetailsService:
@@ -182,6 +183,13 @@ class PublicationDetailsService:
 
         return payload
 
+    @traced(
+        "publication_details_service.get_publications_for_details_page",
+        attrs=lambda self, *, doi, excluded_sources: {
+            "publication.doi": doi,
+            "sources.excluded_count": len(excluded_sources),
+        }
+    )
     def get_publications_for_details_page(
         self,
         *,

--- a/nfdi_search_engine/services/researcher_details_service.py
+++ b/nfdi_search_engine/services/researcher_details_service.py
@@ -11,6 +11,7 @@ from nfdi_search_engine.common.models.details_settings import DetailsSettings
 from nfdi_search_engine.common.models.openai_settings import OpenAISettings
 from nfdi_search_engine.services.tracking_service import TrackingService
 from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+from nfdi_search_engine.infra.observability.decorators import traced
 
 
 class ResearcherDetailsService:
@@ -36,6 +37,13 @@ class ResearcherDetailsService:
         self.http = http or requests.Session()
         self.merger = ObjectMerger()
 
+    @traced(
+        "researcher_details_service.get_researchers_for_details_page",
+        attrs=lambda self, *, orcid, excluded_sources: {
+            "researcher.orcid": orcid,
+            "sources.excluded_count": len(excluded_sources),
+        }
+    )
     def get_researchers_for_details_page(
         self,
         *,

--- a/nfdi_search_engine/services/resource_details_service.py
+++ b/nfdi_search_engine/services/resource_details_service.py
@@ -9,6 +9,7 @@ import requests
 from nfdi_search_engine.common.models.objects import CreativeWork
 from nfdi_search_engine.common.models.details_settings import DetailsSettings
 from nfdi_search_engine.services.tracking_service import TrackingService
+from nfdi_search_engine.infra.observability.decorators import traced
 
 
 class ResourceDetailsService:
@@ -29,6 +30,13 @@ class ResourceDetailsService:
         self.tracking = tracking
         self.http = http
 
+    @traced(
+        "resource_details_service.get_resource_details",
+        attrs=lambda self, doi, source_name: {
+            "resource.doi": doi,
+            "source.name": source_name,
+        }
+    )
     def get_resource_details(self, doi: str, source_name: str) -> Optional[CreativeWork]:
         """
         Returns resource details for the given doi from the given source.

--- a/nfdi_search_engine/services/search_service.py
+++ b/nfdi_search_engine/services/search_service.py
@@ -195,6 +195,7 @@ class SearchService:
         "search_service.load_more",
         attrs=lambda self, ctx: {
             "search.id": ctx.search_id,
+            "search.object_type": ctx.object_type,
         }
     )
     def load_more(self, ctx: SearchContext) -> List[Any]:
@@ -280,6 +281,7 @@ class SearchService:
         "search_service._harvest",
         attrs=lambda self, sources, search_term: {
             "search.term": search_term,
+            "search.n_sources": len(sources),
         }
     )
     def _harvest(self, sources: List[str], search_term: str) -> Tuple[Dict[str, List[Any]], List[str]]:

--- a/nfdi_search_engine/services/search_service.py
+++ b/nfdi_search_engine/services/search_service.py
@@ -5,6 +5,7 @@ import traceback
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, List, Optional, Set, Tuple
 from rank_bm25 import BM25Plus
+from opentelemetry import trace
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -14,7 +15,10 @@ from nfdi_search_engine.common.models.request_meta import RequestMeta
 from nfdi_search_engine.infra.store.result_store import ResultStore
 from nfdi_search_engine.services.chatbot_service import ChatbotService
 from nfdi_search_engine.services.tracking_service import TrackingService
+from nfdi_search_engine.infra.observability.context import with_parent_context
+from nfdi_search_engine.infra.observability.decorators import traced
 
+tracer = trace.get_tracer("nfdi_search_engine")
 
 CATEGORIES: List[str] = [
     "publications",
@@ -98,6 +102,13 @@ class SearchService:
         self.tracking = tracking
         self.deduplication = deduplication
 
+    @traced(
+        "search_service.run_search",
+        attrs=lambda self, ctx: {
+            "search.id": ctx.search_id,
+            "search.term": ctx.search_term
+        }
+    )
     def run_search(self, ctx: SearchContext) -> SearchPage:
         """
         Execute a search request end-to-end and return the first-page results.
@@ -180,6 +191,12 @@ class SearchService:
             failed_sources=failed_sources,
         )
 
+    @traced(
+        "search_service.load_more",
+        attrs=lambda self, ctx: {
+            "search.id": ctx.search_id,
+        }
+    )
     def load_more(self, ctx: SearchContext) -> List[Any]:
         """
         Load the next chunk of results for a single category (lazy-load / pagination).
@@ -259,6 +276,12 @@ class SearchService:
                 traceback=traceback.format_exception(e),
             )
 
+    @traced(
+        "search_service._harvest",
+        attrs=lambda self, sources, search_term: {
+            "search.term": search_term,
+        }
+    )
     def _harvest(self, sources: List[str], search_term: str) -> Tuple[Dict[str, List[Any]], List[str]]:
         """
         Harvest search results across multiple data sources in parallel.
@@ -278,20 +301,25 @@ class SearchService:
         failed: List[str] = []
 
         def search_source(module_name: str, term: str) -> tuple[Optional[dict], Optional[Exception]]:
-            try:
-                mod = importlib.import_module(f"sources.{module_name}")
-                partial = {c: [] for c in CATEGORIES}
-                mod.search(
-                    term, partial, tracking=self.tracking
-                )
-                return partial, None
-            except Exception as e:
-                return None, e
+            with tracer.start_as_current_span("source.search") as span:
+                span.set_attribute("source.module", module_name)
+                span.set_attribute("search.term", term)
+                try:
+                    mod = importlib.import_module(f"sources.{module_name}")
+                    partial = {c: [] for c in CATEGORIES}
+                    mod.search(
+                        term, partial, tracking=self.tracking
+                    )
+                    return partial, None
+                except Exception as e:
+                    span.record_exception(e)
+                    return None, e
 
         max_workers = min(self.settings.max_workers, len(sources) or 1)
         with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            search_source_with_ctx = with_parent_context(search_source)
             futures = {
-                ex.submit(search_source, self.settings.data_sources[src]["module"], search_term): src
+                ex.submit(search_source_with_ctx, self.settings.data_sources[src]["module"], search_term): src
                 for src in sources
             }
             for fut in as_completed(futures):
@@ -315,6 +343,12 @@ class SearchService:
 
         return results, failed
 
+    @traced(
+        "search_service.sort_search_results",
+        attrs=lambda self, search_term, search_results: {
+            "search.term": search_term
+        }
+    )
     def _sort_search_results(self, search_term, search_results) -> list:
         """
         Rank and sort search results by textual relevance using BM25Plus.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,8 @@ email-validator==2.2.0
 Flask-Limiter==3.12
 pydantic==2.11.7
 pydantic-settings==2.12.0
+opentelemetry-api==1.39.1
+opentelemetry-sdk==1.39.1
+opentelemetry-exporter-otlp==1.39.1
+opentelemetry-instrumentation-flask==0.60b1
+opentelemetry-instrumentation-requests==0.60b1


### PR DESCRIPTION
This PR implements tracing with opentelemetry.
Traces are saved to elastic, with weekly index rollover.
Instrumentation is implemented for all flask routes and for selected service functions, including
- search 
- details (publications, researchers, resources)
- deduplication

Tracing is enabled by default, but can be disabled in the config.