### PR TITLE
405 ranking algorithm

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,10 +20,11 @@ from nfdi_search_engine.infra.jobs.inprocess_dispatcher import InProcessDispatch
 from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
 from nfdi_search_engine.infra.jobs.chatbot_processor import ChatbotProcessor
 from nfdi_search_engine.services.user_service import UserService
-from nfdi_search_engine.services.search_service import SearchService, SearchSettings
+from nfdi_search_engine.services.search_service import CATEGORIES, SearchService, SearchSettings
 from nfdi_search_engine.services.deduplication import DeduplicationService
 from nfdi_search_engine.services.deduplication.policies import default_policies
 from nfdi_search_engine.services.chatbot_service import ChatbotService, ChatbotSettings
+from nfdi_search_engine.services.ranking import RankingService
 from nfdi_search_engine.services.tracking_service import TrackingService
 from nfdi_search_engine.services.analytics_service import AnalyticsService
 from nfdi_search_engine.services.publication_details_service import PublicationDetailsService, DetailsSettings
@@ -120,12 +121,18 @@ def create_app() -> Flask:
         mapping_preference=app.config.get("MAPPING_PREFERENCE", {}),
     )
 
+    ranking_service = RankingService(
+        categories=CATEGORIES,
+        profile_config=app.config.get("RANKING_PROFILES", {}),
+    )
+
     search_service = SearchService(
         settings=SearchSettings.from_config(app.config),
         chatbot=chatbot_service,
         store=result_store,
         tracking=tracking_service,
         deduplication=deduplication_service,
+        ranking=ranking_service,
     )
 
     pub_details_service = PublicationDetailsService(
@@ -156,6 +163,7 @@ def create_app() -> Flask:
         "tracking": tracking_service,
         "analytics": analytics_service,
         "chatbot": chatbot_service,
+        "ranking": ranking_service,
         "publication_details": pub_details_service,
         "researcher_details": researcher_details_service,
         "resource_details": resource_details_service,

--- a/config.py
+++ b/config.py
@@ -105,7 +105,7 @@ class Config:
     SESSION_TYPE = "filesystem"
 
     REQUEST_HEADER_USER_AGENT = "nfdi4dsBot/1.0 (https://www.nfdi4datascience.de/nfdi4dsBot/; nfdi4dsBot@nfdi4datascience.de)"
-    REQUEST_TIMEOUT = 5
+    REQUEST_TIMEOUT = 10
 
     NUMBER_OF_RECORDS_TO_SHOW_ON_PAGE_LOAD = 20
     NUMBER_OF_RECORDS_TO_APPEND_ON_LAZY_LOAD = 10
@@ -498,6 +498,143 @@ class Config:
         },
     }
 
+    RANKING_PROFILES = {
+        "__default__": {
+            "field_weights": {
+                "identifier": 20.0,
+                "name": 10.0,
+                "title": 10.0,
+                "aliases": 5.0,
+                "keywords": 3.0,
+                "authors": 3.0,
+                "description": 2.0,
+                "source": 1.0,
+                "type": 1.0,
+                "url": 1.0,
+                "publication": 1.0,
+                "publisher": 1.0,
+                "language": 0.2,
+                "license": 0.2,
+                "version": 0.5,
+                "status": 1.0,
+                "location": 1.0,
+                "address": 1.0,
+                "legal_name": 3.0,
+            },
+            "numeric_feature_weights": {
+                "citation_count": 1.0,
+                "year": 1.0,
+            },
+            "boolean_feature_weights": {
+                "has_identifier": 3.0,
+                "has_description": 1.0,
+                "has_url": 0.5,
+            },
+            "exact_field_boosts": {
+                "name": 15.0,
+                "title": 15.0,
+            },
+        },
+        "publications": {
+            "field_weights": {
+                "identifier": 30.0,
+                "title": 12.0,
+                "authors": 4.0,
+                "keywords": 4.0,
+                "abstract": 2.0,
+                "body": 1.0,
+                "publication": 1.5,
+                "publisher": 1.0,
+                "source": 0.5,
+                "type": 0.5,
+                "genre": 1.0,
+                "language": 0.2,
+                "license": 0.2,
+                "version": 0.5,
+            },
+            "numeric_feature_weights": {
+                "citation_count": 2.5,
+                "year": 1.5,
+                "reference_count": 0.2,
+            },
+            "boolean_feature_weights": {
+                "has_identifier": 5.0,
+                "has_abstract": 1.0,
+                "has_full_text": 0.5,
+                "has_open_access_url": 0.5,
+            },
+            "exact_field_boosts": {
+                "title": 20.0,
+            },
+        },
+        "researchers": {
+            "field_weights": {
+                "identifier": 30.0,
+                "name": 20.0,
+                "aliases": 12.0,
+                "given_name": 4.0,
+                "family_name": 4.0,
+                "additional_name": 4.0,
+                "affiliations": 3.0,
+                "alumni": 1.0,
+                "works_for": 2.0,
+                "research_areas": 5.0,
+                "about": 2.0,
+                "works": 1.0,
+                "job_title": 1.0,
+                "description": 1.0,
+            },
+            "numeric_feature_weights": {
+                "cited_by_count": 1.5,
+                "works_count": 0.7,
+            },
+            "boolean_feature_weights": {
+                "has_identifier": 8.0,
+                "has_affiliation": 1.0,
+                "has_research_areas": 1.0,
+                "has_works": 0.5,
+            },
+            "exact_field_boosts": {
+                "name": 40.0,
+                "aliases": 25.0,
+            },
+        },
+        "projects": {
+            "field_weights": {
+                "identifier": 15.0,
+                "title": 12.0,
+                "name": 12.0,
+                "aliases": 6.0,
+                "keywords": 4.0,
+                "description": 3.0,
+                "status": 2.0,
+                "funding": 2.0,
+                "funder": 2.0,
+                "sponsor": 1.0,
+                "source_organization": 1.0,
+                "source": 1.0,
+                "type": 0.5,
+                "duration": 0.5,
+                "publication": 0.5,
+                "language": 0.2,
+            },
+            "numeric_feature_weights": {
+                "year": 1.2,
+            },
+            "boolean_feature_weights": {
+                "has_identifier": 3.0,
+                "has_description": 1.0,
+                "has_dates": 0.5,
+                "has_funding": 0.5,
+            },
+            "exact_field_boosts": {
+                "title": 20.0,
+                "name": 20.0,
+                "aliases": 10.0,
+            },
+        },
+    }
+
     ELASTIC = {
         "server": app_settings.ELASTIC_SERVER,
         "username": app_settings.ELASTIC_USERNAME,
@@ -557,5 +694,3 @@ class Config:
         502: "Error 502: Bad Gateway.",
         503: "Error 503: Service Unavailable.",
     }
-
-    

--- a/nfdi_search_engine/common/models/search_result.py
+++ b/nfdi_search_engine/common/models/search_result.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class FieldContribution:
+    source: str
+    selected: bool
+    value_preview: str = ""
+
+
+@dataclass(frozen=True)
+class FieldProvenance:
+    field: str
+    strategy: str
+    contributions: list[FieldContribution] = field(default_factory=list)
+
+
+@dataclass
+class RankingInfo:
+    score: float = 0.0
+    text_score: float = 0.0
+    feature_score: float = 0.0
+    signals: dict[str, float] = field(default_factory=dict)
+    profile: str = ""
+
+
+@dataclass
+class SearchResult(Generic[T]):
+    category: str
+    entity_key: str
+    item: T
+    sources: list[str] = field(default_factory=list)
+    provenance: dict[str, FieldProvenance] = field(default_factory=dict)
+    ranking: RankingInfo = field(default_factory=RankingInfo)
+
+    # for debugging
+    source_items: list[Any] = field(default_factory=list, repr=False)

--- a/nfdi_search_engine/common/strings.py
+++ b/nfdi_search_engine/common/strings.py
@@ -1,0 +1,16 @@
+import re
+
+
+TOKEN_RE = re.compile(r"[a-zA-Z0-9]+")
+
+
+def tokenize(text: str) -> list[str]:
+    return TOKEN_RE.findall(text.lower())
+
+
+def flatten_string_value(value: str | list[str] | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return " ".join(str(v) for v in value if v)
+    return str(value)

--- a/nfdi_search_engine/infra/jobs/chatbot_processor.py
+++ b/nfdi_search_engine/infra/jobs/chatbot_processor.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 import requests
 
+from nfdi_search_engine.common.models.search_result import SearchResult
 from nfdi_search_engine.common.models.chatbot_settings import ChatbotSettings
 from nfdi_search_engine.infra.store.result_store import ResultStore
 
@@ -13,6 +14,7 @@ class ChatbotProcessor:
     """
     Provides job handlers for asynchronous chatbot operations
     """
+
     def __init__(self, result_store: ResultStore, settings: ChatbotSettings, http_timeout_s: int = 30):
         self.store = result_store
         self.settings = settings
@@ -31,7 +33,15 @@ class ChatbotProcessor:
         )
         request_url = f"{base_url}/{search_id}"
 
-        results_json = json.dumps(rec.results, default=vars)
+        # compatibility with SearchResult type
+        results = {}
+        for category, rows in rec.results.items():
+            results[category] = [
+                row.item if isinstance(row, SearchResult) else row
+                for row in rows
+            ]
+
+        results_json = json.dumps(results, default=vars)
         resp = requests.post(
             request_url,
             json=results_json,

--- a/nfdi_search_engine/services/deduplication/merger.py
+++ b/nfdi_search_engine/services/deduplication/merger.py
@@ -1,16 +1,43 @@
+import hashlib
 import logging
 from typing import Any
 
+from nfdi_search_engine.common.models.search_result import (
+    FieldContribution,
+    FieldProvenance,
+    SearchResult,
+)
 from nfdi_search_engine.services.deduplication.normalize import normalize_string
 
 log = logging.getLogger(__name__)
 
 
-def _source_name(obj: Any) -> str | None:
-    """Helper to get the source name of an object"""
+def _is_empty(value: Any) -> bool:
+    return value is None or value == "" or value == [] or value == {}
+
+
+def _source_names(obj: Any) -> list[str]:
     sources = getattr(obj, "source", None)
-    source = sources[0] if sources else None
-    return getattr(source, "name", None) if source else None
+    names = []
+
+    if isinstance(sources, str):
+        names.append(sources)
+    elif isinstance(sources, list):
+        for source in sources:
+            if isinstance(source, str):
+                names.append(source)
+            elif name := getattr(source, "name", ""):
+                names.append(name)
+
+    if not names and (original_source := getattr(obj, "originalSource", "")):
+        names.append(original_source)
+
+    return list(dict.fromkeys(name for name in names if name))
+
+
+def _source_name(obj: Any) -> str | None:
+    names = _source_names(obj)
+    return names[0] if names else None
 
 
 def _preference_index(obj: Any, field: str, mapping_preference: dict) -> float:
@@ -18,7 +45,10 @@ def _preference_index(obj: Any, field: str, mapping_preference: dict) -> float:
     Helper to get the preference index of an object's field value based on its source.
     See MAPPING_PREFERENCE in config.py.
     """
-    pref = mapping_preference.get(field, mapping_preference.get("__default__", []))
+    pref = mapping_preference.get(
+        field,
+        mapping_preference.get("__default__", [])
+    )
     if not isinstance(pref, list):
         return float("inf")
     src = _source_name(obj)
@@ -27,88 +57,214 @@ def _preference_index(obj: Any, field: str, mapping_preference: dict) -> float:
 
 class ObjectMerger:
     """
-    ObjectMerger can be used to merge a list of result objects into one.
-    There are different strategies for merging each field, defined by the mapping_preference dict passed to merge().
+    Merge source objects according to MAPPING_PREFERENCE.
+
+    When category is omitted this returns one merged domain object.
+    When category is provided it returns a SearchResult with provenance metadata for search-result storage/ranking.
     """
 
-    def merge(self, group: list[Any], mapping_preference: dict) -> Any:
-        """Merge a list of result objects into one, applying strategies from mapping_preference."""
-        if not group:
+    def merge(
+        self,
+        group: list[Any],
+        mapping_preference: dict,
+        category: str | None = None,
+        entity_key: str = "",
+    ) -> Any:
+        """
+        Merge a list of result objects into one.
+        Returns a SearchResult if a category if provided, the domain object otherwise.
+        Applies strategies from mapping_preference and adds the provenance record.
+        """
+        source_items = self._source_items(group)
+        if not source_items:
             log.warning("ObjectMerger.merge() called with an empty list")
             return None
 
         # pick the most specific class among the group as the target type for merging
         # i.e. if we get ['thing', 'thing', 'Publication', 'thing'], we want to merge into a Publication
-        target_cls = type(max(group, key=lambda x: len(type(x).__mro__)))
+        target_cls = type(max(
+            source_items,
+            key=lambda x: len(type(x).__mro__)
+        ))
         merged = target_cls()
+        provenance = {}
 
         # iterate through all fields of the target class
         for field in type(merged).model_fields:
             # default source to "union" so we always collect all sources
-            strategy = mapping_preference.get(field) or ("union" if field == "source" else None)
+            strategy = mapping_preference.get(field) or (
+                "union" if field == "source" else "preference"
+            )
 
             # build the merged value for this field based on the strategy
             if strategy == "max":
-                val = self._apply_max(group, field)
+                value, field_provenance = self._value_max(group, field)
             elif strategy == "union":
-                val = self._apply_union(group, field) or None
+                value, field_provenance = self._value_union(group, field)
             else:
-                val = self._apply_preference(group, field, mapping_preference)
+                value, field_provenance = self._value_preference(
+                    group,
+                    field,
+                    mapping_preference
+                )
 
-            if val not in (None, "", [], {}):
+            if not _is_empty(value):
                 try:
                     # finally, set the merged value on the merged object
-                    setattr(merged, field, val)
+                    setattr(merged, field, value)
                 except Exception:
-                    log.warning("Could not set field %r on %s during merge, skipping", field, target_cls.__name__)
+                    log.warning(
+                        "Could not set field %r on %s during merge, skipping", field, target_cls.__name__)
 
-        return merged
+            if field_provenance.contributions:
+                provenance[field] = field_provenance
 
-    def _apply_max(self, group: list, field: str) -> str | None:
+        if category is None:
+            return merged
+
+        return SearchResult(
+            category=category,
+            entity_key=entity_key or self._entity_key(category, merged),
+            item=merged,
+            sources=self._sources(source_items),
+            provenance=provenance,
+            source_items=source_items,
+        )
+
+    def _contribution(self, obj: Any, field: str, selected: bool) -> FieldContribution:
+        return FieldContribution(
+            source=_source_name(obj) or type(obj).__name__,
+            selected=selected,
+            value_preview=self._preview(getattr(obj, field, "")),
+        )
+
+    def _value_max(self, group: list[Any], field: str) -> tuple[Any, FieldProvenance]:
         """
-        Return the largest number for a field across all objects, as a string.
+        Return the largest number and the provenance record for a field across all objects.
 
         Used e.g. for citationCount, referenceCount, works_count, cited_by_count.
         """
-        best = None
+        candidates = []
         for obj in group:
             try:
-                v = float(getattr(obj, field, None))
-                if best is None or v > best:
-                    best = v
+                candidates.append((float(getattr(obj, field, None)), obj))
             except (TypeError, ValueError):
-                pass
-        if best is None:
-            return None
-        return str(int(best)) if best.is_integer() else str(best)
+                continue
 
-    def _apply_union(self, group: list, field: str) -> list:
+        if not candidates:
+            return None, FieldProvenance(field=field, strategy="max")
+
+        best = max(numeric for numeric, _ in candidates)
+        winner = next(obj for numeric, obj in candidates if numeric == best)
+        value = getattr(winner, field)
+
+        contributions = [
+            self._contribution(obj, field, numeric == best)
+            for numeric, obj in candidates
+        ]
+        return value, FieldProvenance(field=field, strategy="max", contributions=contributions)
+
+    def _value_union(self, group: list[Any], field: str) -> tuple[Any, FieldProvenance]:
         """
         Concatenate list fields across all objects, deduplicating by _union_key.
 
         Used e.g. for affiliation, alternateName, researchAreas, keywords.
         """
-        seen, combined = set(), []
+        field_lists = {id(obj): self._as_list(
+            getattr(obj, field, None)) for obj in group}
+
+        seen: set = set()
+        combined: list[Any] = []
+        contributing_ids: set = set()  # objects that supplied at least one new item
         for obj in group:
-            for item in (getattr(obj, field, None) or []):
+            for item in field_lists[id(obj)]:
                 key = self._union_key(item)
                 if key not in seen:
                     seen.add(key)
                     combined.append(item)
-        return combined
+                    contributing_ids.add(id(obj))
 
-    def _apply_preference(self, group: list, field: str, mapping_preference: dict) -> Any:
+        contributions = [
+            self._contribution(obj, field, id(obj) in contributing_ids)
+            for obj in group
+            if field_lists[id(obj)]
+        ]
+        return combined, FieldProvenance(field=field, strategy="union", contributions=contributions)
+
+    def _value_preference(
+        self, group: list[Any], field: str, mapping_preference: dict
+    ) -> tuple[Any, FieldProvenance]:
         """
         Pick the first non-empty value in source-preference order.
 
         I.e. if the mapping_preference for this field is ["sourceA", "sourceB", "sourceC"]
         and sourceA is empty, sourceB is X and sourceC is Y, we pick X.
         """
+        field_values = {id(obj): getattr(obj, field, None) for obj in group}
+
+        selected_obj = None
         for obj in sorted(group, key=lambda o: _preference_index(o, field, mapping_preference)):
-            val = getattr(obj, field, None)
-            if val not in (None, "", [], {}):
-                return val
-        return None
+            if not _is_empty(field_values[id(obj)]):
+                selected_obj = obj
+                break
+
+        selected_value = field_values[id(
+            selected_obj)] if selected_obj is not None else None
+        contributions = [
+            self._contribution(obj, field, obj is selected_obj)
+            for obj in group
+            if not _is_empty(field_values[id(obj)])
+        ]
+        return selected_value, FieldProvenance(
+            field=field, strategy="preference", contributions=contributions
+        )
+
+    def _source_items(self, group: list[Any]) -> list[Any]:
+        items = []
+        for obj in group:
+            if isinstance(obj, SearchResult):
+                items.extend(obj.source_items or [obj.item])
+            else:
+                items.append(obj)
+        return items
+
+    def _sources(self, group: list[Any]) -> list[str]:
+        seen, names = set(), []
+        for obj in group:
+            for name in _source_names(obj):
+                if name not in seen:
+                    seen.add(name)
+                    names.append(name)
+        return names
+
+    def _entity_key(self, category: str, obj: Any) -> str:
+        for field in ("identifier", "url", "name"):
+            value = getattr(obj, field, "")
+            if value:
+                return f"{category}:{normalize_string(str(value))}"
+
+        digest = hashlib.sha1(str(obj).encode(
+            "utf-8", errors="ignore")).hexdigest()
+        return f"{category}:{digest[:16]}"
+
+    def _as_list(self, value: Any) -> list[Any]:
+        if _is_empty(value):
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        return [value]
+
+    def _preview(self, value: Any) -> str:
+        if _is_empty(value):
+            return ""
+        if isinstance(value, list):
+            value = ", ".join(self._preview(v) for v in value[:3])
+        else:
+            value = getattr(value, "name", None) or str(value)
+        value = " ".join(str(value).split())
+        return value[:160]
 
     def _union_key(self, item: Any) -> str:
         """

--- a/nfdi_search_engine/services/deduplication/service.py
+++ b/nfdi_search_engine/services/deduplication/service.py
@@ -4,6 +4,7 @@ import logging
 from collections import defaultdict
 from typing import Any
 
+from nfdi_search_engine.common.models.search_result import SearchResult
 from nfdi_search_engine.services.deduplication.merger import ObjectMerger
 from nfdi_search_engine.services.deduplication.policies.base import DedupPolicy
 
@@ -24,12 +25,27 @@ class DeduplicationService:
 
     def deduplicate(self, results: dict) -> dict:
         """Deduplicate search results according to the policies."""
+        results = dict(results)
+        policy_categories = set()
         for policy in self.policies:
+            policy_categories.add(policy.category)
             pref = self.mapping_preference.get(policy.category, {})
             objects = results.get(policy.category, [])
             objects = self._primary_pass(objects, policy, pref)
             objects = self._secondary_pass(objects, policy, pref)
             results[policy.category] = objects
+
+        for category, objects in results.items():
+            pref = self.mapping_preference.get(category, {})
+            if category in policy_categories:
+                results[category] = [self._ensure_result(category, obj, pref) for obj in objects]
+            else:
+                results[category] = [
+                    self.merger.merge([obj], pref, category=category)
+                    for obj in objects
+                    if obj is not None
+                ]
+
         return results
 
     def _primary_pass(self, objects: list[Any], policy: DedupPolicy, pref: dict) -> list[Any]:
@@ -43,7 +59,7 @@ class DeduplicationService:
         no_key: list[Any] = []              # objects without a primary key, to be merged individually at the end
 
         for obj in objects:
-            key = next(iter(policy.primary_keys(obj)), None)
+            key = next(iter(policy.primary_keys(self._item(obj))), None)
             if key:
                 keyed.setdefault(key, []).append(obj)
             else:
@@ -51,9 +67,16 @@ class DeduplicationService:
 
         # merge each primary-key cluster
         merged = []
-        for group in keyed.values():
+        for key, group in keyed.items():
             try:
-                merged.append(self.merger.merge(group, pref))
+                merged.append(
+                    self.merger.merge(
+                        group,
+                        pref,
+                        category=policy.category,
+                        entity_key=f"{policy.category}:{key}",
+                    )
+                )
             except Exception as e:
                 log.warning("merge failed for primary-key cluster (%s): %s", [getattr(o, "identifier", None) for o in group], e)
                 merged.extend(group)
@@ -61,7 +84,7 @@ class DeduplicationService:
         # merge keyless objects individually (e.g. to clean up union fields)
         for obj in no_key:
             try:
-                merged.append(self.merger.merge([obj], pref))
+                merged.append(self.merger.merge([obj], pref, category=policy.category))
             except Exception as e:
                 log.warning("merge failed for keyless object: %s", e)
                 merged.append(obj)
@@ -79,7 +102,7 @@ class DeduplicationService:
             return objects
 
         # build key -> object index map
-        key_sets = [list(policy.secondary_keys(obj)) for obj in objects]
+        key_sets = [list(policy.secondary_keys(self._item(obj))) for obj in objects]
         key_to_indices: dict[str, list[int]] = defaultdict(list)
         for i, keys in enumerate(key_sets):
             for key in keys:
@@ -111,10 +134,10 @@ class DeduplicationService:
                 continue
 
             # should we merge this cluster?
-            if policy.should_merge_secondary_group(group):
+            if policy.should_merge_secondary_group([self._item(obj) for obj in group]):
                 # merge it
                 try:
-                    result.append(self.merger.merge(group, pref))
+                    result.append(self.merger.merge(group, pref, category=policy.category))
                 except Exception as e:
                     log.warning("merge failed for secondary-key cluster: %s", e)
                     result.extend(group)
@@ -123,3 +146,11 @@ class DeduplicationService:
                 result.extend(group)
 
         return result
+
+    def _ensure_result(self, category: str, obj: Any, pref: dict) -> SearchResult:
+        if isinstance(obj, SearchResult):
+            return obj
+        return self.merger.merge([obj], pref, category=category)
+
+    def _item(self, obj: Any) -> Any:
+        return obj.item if isinstance(obj, SearchResult) else obj

--- a/nfdi_search_engine/services/ranking/__init__.py
+++ b/nfdi_search_engine/services/ranking/__init__.py
@@ -1,0 +1,3 @@
+from nfdi_search_engine.services.ranking.service import RankingService
+
+__all__ = ["RankingService"]

--- a/nfdi_search_engine/services/ranking/adapters.py
+++ b/nfdi_search_engine/services/ranking/adapters.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from nfdi_search_engine.common.models.objects import Article, Author, Project
+
+
+@dataclass(frozen=True)
+class RankingDocument:
+    """
+    Normalized document passed from ranking adapters to ranking scorers.
+
+    RankingDocument separates the raw domain object from the fields and features used for
+    scoring. Text fields are used by FieldWeightedTextScorer, numeric and boolean features
+    are used by FeatureScorer.
+    """
+
+    id: str
+    category: str
+    raw: Any
+
+    fields: dict[str, str | list[str]] = field(default_factory=dict)
+    numeric_features: dict[str, float | None] = field(default_factory=dict)
+    boolean_features: dict[str, bool] = field(default_factory=dict)
+
+
+class RankingAdapter(Protocol):
+    """
+    Interface for converting domain objects into RankingDocument objects.
+
+    A ranking adapter is category-specific and should only support objects that can be
+    represented meaningfully for that category's ranking profile.
+    """
+
+    category: str
+
+    def supports(self, obj: object) -> bool:
+        """
+        Return whether this adapter can convert the given domain object.
+        """
+        ...
+
+    def to_document(self, obj: object) -> RankingDocument:
+        """
+        Convert a supported domain object into a RankingDocument.
+        """
+        ...
+
+
+class ArticleRankingAdapter(RankingAdapter):
+    """
+    Ranking adapter for publication search results represented as Article objects.
+
+    Extracts publication-specific text fields such as title, abstract, keywords and authors,
+    plus feature signals such as citation count, reference count and publication year.
+    """
+
+    category = "publications"
+
+    def supports(self, obj: object) -> bool:
+        return isinstance(obj, Article)
+
+    def to_document(self, obj: Article) -> RankingDocument:
+        title = obj.headline or obj.name or obj.alternativeHeadline
+
+        authors = _names(obj.author)
+        publisher = _name(obj.publisher)
+        source_names = _source_names(obj)
+
+        return RankingDocument(
+            id=obj.identifier or obj.url or hash_fallback(obj),
+            category=self.category,
+            raw=obj,
+            fields={
+                "identifier": obj.identifier,
+                "title": title,
+                "aliases": obj.alternateName,
+                "abstract": obj.abstract or obj.description,
+                "body": obj.text or obj.articleBody,
+                "keywords": obj.keywords,
+                "authors": authors,
+                "source": source_names or obj.originalSource,
+                "publication": obj.publication,
+                "publisher": publisher,
+                "language": obj.inLanguage,
+                "license": obj.license,
+                "type": obj.additionalType,
+                "genre": obj.genre,
+                "version": obj.version,
+            },
+            numeric_features={
+                "citation_count": safe_float(obj.citationCount),
+                "reference_count": safe_float(obj.referenceCount),
+                "year": safe_year(obj.datePublished or obj.dateCreated or obj.dateModified),
+            },
+            boolean_features={
+                "has_identifier": bool(obj.identifier),
+                "has_abstract": bool(obj.abstract or obj.description),
+                "has_full_text": bool(obj.text or obj.articleBody),
+                "has_open_access_url": bool(obj.encoding_contentUrl),
+            },
+        )
+
+
+class AuthorRankingAdapter:
+    """
+    Ranking adapter for researcher search results represented as Author objects.
+
+    Extracts name variants, affiliation/research-area text, optional generated profile text,
+    works metadata, and researcher metrics such as works count and citation count.
+    """
+
+    category = "researchers"
+
+    def supports(self, obj: object) -> bool:
+        return isinstance(obj, Author)
+
+    def to_document(self, obj: Author) -> RankingDocument:
+        affiliations = _names(obj.affiliation)
+        alumni = _names(obj.alumniOf)
+        works = _titles(obj.works)
+        works_for = _name(obj.worksFor)
+
+        return RankingDocument(
+            id=obj.identifier or obj.url or hash_fallback(obj),
+            category=self.category,
+            raw=obj,
+            fields={
+                "identifier": obj.identifier,
+                "name": obj.name,
+                "given_name": obj.givenName,
+                "family_name": obj.familyName,
+                "additional_name": obj.additionalName,
+                "aliases": obj.alternateName,
+                "description": obj.description,
+                "job_title": obj.jobTitle,
+                "affiliations": affiliations,
+                "alumni": alumni,
+                "works_for": works_for,
+                "research_areas": obj.researchAreas,
+                "about": obj.about,
+                "works": works,
+            },
+            numeric_features={
+                "works_count": safe_float(obj.works_count),
+                "cited_by_count": safe_float(obj.cited_by_count),
+            },
+            boolean_features={
+                "has_identifier": bool(obj.identifier),
+                "has_affiliation": bool(affiliations),
+                "has_research_areas": bool(obj.researchAreas),
+                "has_works": bool(works),
+            },
+        )
+
+
+class ProjectRankingAdapter:
+    """
+    Ranking adapter for project search results represented as Project objects.
+
+    Extracts project title/description, funding/status metadata and date/cost-like features.
+    """
+
+    category = "projects"
+
+    def supports(self, obj: object) -> bool:
+        return isinstance(obj, Project)
+
+    def to_document(self, obj: Project) -> RankingDocument:
+        funder = _name(obj.funder)
+        sponsor = _name(obj.sponsor)
+        source_org = _name(obj.sourceOrganization)
+        source_names = _source_names(obj)
+
+        return RankingDocument(
+            id=obj.identifier or obj.url or hash_fallback(obj),
+            category=self.category,
+            raw=obj,
+            fields={
+                "identifier": obj.identifier,
+                "name": obj.name,
+                "title": obj.headline or obj.name or obj.alternativeHeadline,
+                "aliases": obj.alternateName,
+                "description": obj.abstract or obj.description or obj.text,
+                "keywords": obj.keywords,
+                "source": source_names or obj.originalSource,
+                "type": obj.additionalType,
+                "status": obj.status,
+                "funding": obj.funding,
+                "funder": funder,
+                "sponsor": sponsor,
+                "source_organization": source_org,
+                "date_start": obj.dateStart,
+                "date_end": obj.dateEnd,
+                "duration": obj.duration,
+                "currency": obj.currency,
+                "publication": obj.publication,
+                "language": obj.inLanguage,
+            },
+            numeric_features={
+                "year": safe_year(obj.dateStart or obj.datePublished or obj.dateCreated),
+                "total_cost": safe_float(obj.totalCost),
+                "funded_amount": safe_float(obj.fundedAmount),
+                "eu_contribution": safe_float(obj.eu_contribution),
+            },
+            boolean_features={
+                "has_identifier": bool(obj.identifier),
+                "has_description": bool(obj.abstract or obj.description or obj.text),
+                "has_dates": bool(obj.dateStart or obj.dateEnd),
+                "has_funding": bool(obj.funding or obj.funder or obj.fundedAmount or obj.eu_contribution),
+            },
+        )
+
+
+class SchemaObjectRankingAdapter:
+    """
+    Generic adapter for categories without a dedicated ranking adapter.
+
+    Extracts a conservative set of common text fields to give every category a stable
+    baseline ranking instead of failing when no specialized adapter exists.
+    Missing fields are treated as empty values.
+    """
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+
+    def supports(self, obj: object) -> bool:
+        return True
+
+    def to_document(self, obj: object) -> RankingDocument:
+        authors = _names(getattr(obj, "author", None))
+        publisher = _name(getattr(obj, "publisher", None))
+        source_names = _source_names(obj)
+
+        fields = {
+            "identifier": getattr(obj, "identifier", ""),
+            "url": getattr(obj, "url", ""),
+            "name": getattr(obj, "name", ""),
+            "title": (
+                getattr(obj, "headline", "")
+                or getattr(obj, "name", "")
+                or getattr(obj, "alternativeHeadline", "")
+            ),
+            "aliases": _as_list(getattr(obj, "alternateName", None)),
+            "description": (
+                getattr(obj, "abstract", "")
+                or getattr(obj, "description", "")
+                or getattr(obj, "text", "")
+            ),
+            "keywords": _as_list(getattr(obj, "keywords", None)),
+            "authors": authors,
+            "source": source_names or getattr(obj, "originalSource", ""),
+            "type": getattr(obj, "additionalType", ""),
+            "publication": getattr(obj, "publication", ""),
+            "publisher": publisher,
+            "language": _as_list(getattr(obj, "inLanguage", None)),
+            "license": getattr(obj, "license", ""),
+            "version": getattr(obj, "version", ""),
+            "status": getattr(obj, "status", ""),
+            "location": getattr(obj, "location", ""),
+            "address": getattr(obj, "address", ""),
+            "legal_name": getattr(obj, "legalName", ""),
+        }
+
+        return RankingDocument(
+            id=getattr(obj, "identifier", "") or getattr(obj, "url", "") or hash_fallback(obj),
+            category=self.category,
+            raw=obj,
+            fields=fields,
+            numeric_features={
+                "citation_count": safe_float(getattr(obj, "citationCount", 0)),
+                "reference_count": safe_float(getattr(obj, "referenceCount", 0)),
+                "year": safe_year(
+                    getattr(obj, "datePublished", "")
+                    or getattr(obj, "dateCreated", "")
+                    or getattr(obj, "dateStart", "")
+                ),
+            },
+            boolean_features={
+                "has_identifier": bool(getattr(obj, "identifier", "")),
+                "has_description": bool(fields["description"]),
+                "has_url": bool(getattr(obj, "url", "")),
+            },
+        )
+
+
+def safe_float(value: Any) -> float | None:
+    if value in (None, "", [], {}):
+        return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        cleaned = re.sub(r"[^0-9.\-]", "", str(value))
+        return float(cleaned) if cleaned else None
+    except (TypeError, ValueError):
+        return None
+
+
+def safe_year(value: Any) -> float | None:
+    if value in (None, "", [], {}):
+        return None
+
+    match = re.search(r"\b(19|20)\d{2}\b", str(value))
+    if not match:
+        return None
+
+    return float(match.group(0))
+
+
+def hash_fallback(obj: object) -> str:
+    digest = hashlib.sha1(str(obj).encode("utf-8", errors="ignore")).hexdigest()
+    return digest[:16]
+
+
+def _name(value: Any) -> str:
+    if value in (None, "", [], {}):
+        return ""
+    if isinstance(value, str):
+        return value
+    return getattr(value, "name", "") or str(value)
+
+
+def _names(value: Any) -> list[str]:
+    return [name for item in _as_list(value) if (name := _name(item))]
+
+
+def _titles(value: Any) -> list[str]:
+    titles = []
+    for item in _as_list(value):
+        title = (
+            getattr(item, "headline", "")
+            or getattr(item, "name", "")
+            or getattr(item, "alternativeHeadline", "")
+            or getattr(item, "title", "")
+        )
+        if title:
+            titles.append(title)
+    return titles
+
+
+def _source_names(obj: object) -> list[str]:
+    source_names = []
+    for source in _as_list(getattr(obj, "source", None)):
+        name = source if isinstance(source, str) else getattr(source, "name", "")
+        if name:
+            source_names.append(name)
+    return list(dict.fromkeys(source_names))
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value in (None, "", [], {}):
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]

--- a/nfdi_search_engine/services/ranking/profile.py
+++ b/nfdi_search_engine/services/ranking/profile.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RankingProfile:
+    """
+    Category-specific ranking configuration.
+
+    A profile defines which document fields and features should contribute to ranking and
+    how strongly each signal should be weighted. Profiles are loaded from Config.RANKING_PROFILES.
+    """
+
+    category: str
+
+    field_weights: dict[str, float]
+    numeric_feature_weights: dict[str, float] = field(default_factory=dict)
+    boolean_feature_weights: dict[str, float] = field(default_factory=dict)
+    exact_field_boosts: dict[str, float] = field(default_factory=dict)
+
+    phrase_boost: float = 2.0
+    exact_identifier_boost: float = 50.0
+
+    @classmethod
+    def from_dict(cls, category: str, data: dict[str, Any]) -> "RankingProfile":
+        """
+        Build a RankingProfile from configuration data.
+
+        Missing optional sections default to empty mappings, which makes a profile score-neutral
+        for those signal types.
+
+        :param category: Search category this profile belongs to.
+        :type category: str
+        :param data: Profile configuration dictionary.
+        :type data: dict[str, Any]
+        :return: Parsed ranking profile.
+        :rtype: RankingProfile
+        """
+        return cls(
+            category=category,
+            field_weights=dict(data.get("field_weights", {})),
+            numeric_feature_weights=dict(data.get("numeric_feature_weights", {})),
+            boolean_feature_weights=dict(data.get("boolean_feature_weights", {})),
+            exact_field_boosts=dict(data.get("exact_field_boosts", {})),
+            phrase_boost=float(data.get("phrase_boost", 2.0)),
+            exact_identifier_boost=float(data.get("exact_identifier_boost", 50.0)),
+        )

--- a/nfdi_search_engine/services/ranking/query.py
+++ b/nfdi_search_engine/services/ranking/query.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from nfdi_search_engine.common.strings import tokenize
+
+
+@dataclass
+class Query:
+    """
+    Parsed representation of a user search query.
+
+    Carries the normalized raw query string for phrase/exact matching and a token list for
+    text-overlap scoring.
+    """
+
+    raw: str
+    tokens: list[str]
+
+    @classmethod
+    def from_string(cls, query: str) -> "Query":
+        return cls(raw=query.strip().lower(), tokens=tokenize(query))

--- a/nfdi_search_engine/services/ranking/scorers.py
+++ b/nfdi_search_engine/services/ranking/scorers.py
@@ -1,0 +1,256 @@
+import math
+from collections import Counter
+from datetime import date
+
+from nfdi_search_engine.common.strings import tokenize, flatten_string_value
+from nfdi_search_engine.services.ranking.query import Query
+from nfdi_search_engine.services.ranking.adapters import RankingDocument
+from nfdi_search_engine.services.ranking.profile import RankingProfile
+
+
+class FieldWeightedTextScorer:
+    """
+    Scores textual relevance using configured field weights.
+
+    The scorer compares tokenized query terms against each configured text field in a
+    RankingDocument. It applies light term-frequency saturation, an optional phrase boost,
+    and length normalization so very long text fields do not dominate shorter high-signal
+    fields such as title or name.
+    """
+
+    def score(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> float:
+        """
+        Return the total text score for a query/document/profile combination.
+
+        :param query: Parsed search query.
+        :type query: Query
+        :param doc: Ranking document built by a RankingAdapter.
+        :type doc: RankingDocument
+        :param profile: Category-specific ranking profile.
+        :type profile: RankingProfile
+        :return: Sum of all text signal scores.
+        :rtype: float
+        """
+        return sum(self.score_details(query, doc, profile).values())
+
+    def score_details(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        """
+        Return individual text score signals.
+
+        Keys are signal names such as "text.title" or "text.abstract"; values are weighted
+        score contributions. The detailed map is stored in RankingInfo.signals for later
+        debugging, explanation or UI display.
+
+        :return: Mapping of text signal name to weighted score contribution.
+        :rtype: dict[str, float]
+        """
+        if not query.tokens:
+            return {}
+
+        scores = {}
+
+        for field_name, weight in profile.field_weights.items():
+            value = flatten_string_value(doc.fields.get(field_name))
+            if not value:
+                continue
+
+            field_text = value.lower()
+            field_tokens = tokenize(field_text)
+
+            if not field_tokens:
+                continue
+
+            token_counts = Counter(field_tokens)
+
+            # Basic term overlap with light term frequency saturation.
+            field_score = 0.0
+            for token in query.tokens:
+                tf = token_counts.get(token, 0)
+                if tf:
+                    field_score += 1.0 + math.log(tf)
+
+            # Phrase boost.
+            if query.raw and query.raw in field_text:
+                field_score *= profile.phrase_boost
+
+            # Normalize a bit so huge text fields do not dominate.
+            field_score /= math.sqrt(len(field_tokens))
+
+            weighted_score = weight * field_score
+            if weighted_score:
+                scores[f"text.{field_name}"] = weighted_score
+
+        return scores
+
+
+class FeatureScorer:
+    """
+    Scores non-text ranking features.
+
+    Feature signals include identifier matches, exact configured field matches, numeric
+    features such as citation counts or years, and boolean completeness features such as
+    "has_identifier".
+    """
+
+    def score(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> float:
+        """
+        Return the total feature score for a query/document/profile combination.
+
+        :param query: Parsed search query.
+        :type query: Query
+        :param doc: Ranking document built by a RankingAdapter.
+        :type doc: RankingDocument
+        :param profile: Category-specific ranking profile.
+        :type profile: RankingProfile
+        :return: Sum of all feature signal scores.
+        :rtype: float
+        """
+        return sum(self.score_details(query, doc, profile).values())
+
+    def score_details(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        """
+        Return individual feature score signals.
+
+        Keys are signal names such as "feature.identifier.exact" or
+        "feature.citation_count"; values are weighted score contributions.
+
+        :return: Mapping of feature signal name to weighted score contribution.
+        :rtype: dict[str, float]
+        """
+        scores = {}
+        scores.update(self._identifier_scores(query, doc, profile))
+        scores.update(self._exact_field_scores(query, doc, profile))
+        scores.update(self._numeric_feature_scores(doc, profile))
+        scores.update(self._boolean_feature_scores(doc, profile))
+
+        return scores
+
+    def _identifier_scores(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        """
+        Score exact and partial identifier matches.
+
+        This is used for DOI/ORCID-like identifiers where an exact query match should strongly
+        dominate ordinary text overlap.
+        """
+        identifier = flatten_string_value(doc.fields.get("identifier")).lower()
+
+        if not identifier:
+            return {}
+
+        if query.raw == identifier:
+            return {"feature.identifier.exact": profile.exact_identifier_boost}
+
+        if query.raw in identifier or identifier in query.raw:
+            return {"feature.identifier.partial": profile.exact_identifier_boost * 0.5}
+
+        return {}
+
+    def _exact_field_scores(
+        self,
+        query: Query,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        if not query.raw:
+            return {}
+
+        scores = {}
+        for field_name, boost in profile.exact_field_boosts.items():
+            values = _as_strings(doc.fields.get(field_name))
+            for value in values:
+                if value.lower().strip() == query.raw:
+                    scores[f"feature.{field_name}.exact"] = boost
+                    break
+        return scores
+
+    def _numeric_feature_scores(
+        self,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        """
+        Score configured numeric features.
+
+        Count-like features are log-scaled. The "year" feature is converted into a recency
+        score so recent items receive a mild boost without overwhelming relevance.
+        """
+        scores = {}
+
+        for name, weight in profile.numeric_feature_weights.items():
+            value = doc.numeric_features.get(name)
+
+            if value is None:
+                continue
+
+            # Log-scale count-like features.
+            if name.endswith("_count") or name in {"citation_count", "works_count"}:
+                value = math.log1p(max(value, 0.0))
+
+            # Very simple year freshness feature.
+            if name == "year":
+                value = self._year_score(value)
+
+            weighted_score = weight * value
+            if weighted_score:
+                scores[f"feature.{name}"] = weighted_score
+
+        return scores
+
+    def _boolean_feature_scores(
+        self,
+        doc: RankingDocument,
+        profile: RankingProfile,
+    ) -> dict[str, float]:
+        scores = {}
+
+        for name, weight in profile.boolean_feature_weights.items():
+            if doc.boolean_features.get(name):
+                scores[f"feature.{name}"] = weight
+
+        return scores
+
+    def _year_score(self, year: float) -> float:
+        """
+        Convert a publication/start year into a bounded recency score.
+        """
+        if not year:
+            return 0.0
+
+        # Mild recency boost, not dominance.
+        current_year = date.today().year
+        age = max(0.0, current_year - year)
+
+        return 1.0 / (1.0 + age)
+
+
+def _as_strings(value: str | list[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value if v]
+    return [str(value)]

--- a/nfdi_search_engine/services/ranking/service.py
+++ b/nfdi_search_engine/services/ranking/service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nfdi_search_engine.common.models.search_result import RankingInfo, SearchResult
+from nfdi_search_engine.services.ranking.adapters import (
+    ArticleRankingAdapter,
+    AuthorRankingAdapter,
+    ProjectRankingAdapter,
+    RankingAdapter,
+    RankingDocument,
+    SchemaObjectRankingAdapter,
+)
+from nfdi_search_engine.services.ranking.profile import RankingProfile
+from nfdi_search_engine.services.ranking.query import Query
+from nfdi_search_engine.services.ranking.scorers import FieldWeightedTextScorer, FeatureScorer
+
+
+class RankingService:
+    """
+    Service for ranking deduplicated search results.
+
+    This service is responsible for:
+    - Converting domain objects into normalized RankingDocument objects
+    - Applying category-specific RankingProfile configuration
+    - Computing text and feature scores
+    - Writing RankingInfo back onto each SearchResult
+    - Sorting results by descending score
+
+    Ranking profiles are application configuration, not service defaults. If a category has no
+    explicit profile, the optional "__default__" config profile is used.
+    """
+
+    def __init__(
+        self,
+        categories: list[str],
+        profile_config: dict[str, dict[str, Any]],
+        adapters: list[RankingAdapter] | None = None,
+        text_scorer: FieldWeightedTextScorer | None = None,
+        feature_scorer: FeatureScorer | None = None,
+    ) -> None:
+        """
+        Initialize the ranking service.
+
+        :param categories: Search categories that may be ranked.
+        :type categories: list[str]
+        :param profile_config: Ranking profile configuration, usually Config.RANKING_PROFILES.
+        :type profile_config: dict[str, dict[str, Any]]
+        :param adapters: Optional ranking adapters. Defaults to publication, researcher and generic schema adapters.
+        :type adapters: list[RankingAdapter] | None
+        :param text_scorer: Optional text scorer implementation.
+        :type text_scorer: FieldWeightedTextScorer | None
+        :param feature_scorer: Optional feature scorer implementation.
+        :type feature_scorer: FeatureScorer | None
+        """
+        self.profiles = self._profiles(categories, profile_config)
+        self.adapters = adapters or [
+            ArticleRankingAdapter(),
+            AuthorRankingAdapter(),
+            ProjectRankingAdapter(),
+            *[SchemaObjectRankingAdapter(category) for category in categories],
+        ]
+        self.text_scorer = text_scorer or FieldWeightedTextScorer()
+        self.feature_scorer = feature_scorer or FeatureScorer()
+
+    def rank(
+        self,
+        query_text: str,
+        category: str,
+        results: list[SearchResult],
+    ) -> list[SearchResult]:
+        """
+        Rank SearchResult objects for one result category.
+
+        Each SearchResult is adapted to a RankingDocument, scored against the query and category
+        profile, enriched with RankingInfo, and returned in descending score order. The legacy
+        item.rankScore field is also populated while templates and source objects still rely on it.
+
+        :param query_text: User search query.
+        :type query_text: str
+        :param category: Result category, e.g. "publications" or "researchers".
+        :type category: str
+        :param results: Deduplicated SearchResult objects.
+        :type results: list[SearchResult]
+        :return: Ranked SearchResult objects in descending score order.
+        :rtype: list[SearchResult]
+        """
+        query = Query.from_string(query_text)
+        profile = self.profiles.get(category, RankingProfile.from_dict(category, {}))
+
+        ranked = []
+        for result in results:
+            doc = self._to_document(result.item, category)
+            text_signals = self.text_scorer.score_details(query, doc, profile)
+            feature_signals = self.feature_scorer.score_details(query, doc, profile)
+
+            text_score = sum(text_signals.values())
+            feature_score = sum(feature_signals.values())
+            total_score = text_score + feature_score
+
+            if hasattr(doc.raw, "rankScore"):
+                doc.raw.rankScore = total_score
+
+            result.ranking = RankingInfo(
+                score=total_score,
+                text_score=text_score,
+                feature_score=feature_score,
+                signals={**text_signals, **feature_signals},
+                profile=profile.category,
+            )
+            ranked.append(result)
+
+        return sorted(ranked, key=lambda r: r.ranking.score, reverse=True)
+
+    def _profiles(
+        self,
+        categories: list[str],
+        profile_config: dict[str, dict[str, Any]],
+    ) -> dict[str, RankingProfile]:
+        """
+        Build RankingProfile instances for all configured search categories.
+
+        Categories without an explicit profile use the optional "__default__" profile. If neither
+        exists, an empty profile is used, which keeps ranking deterministic but score-neutral.
+        """
+        default_config = profile_config.get("__default__", {})
+        return {
+            category: RankingProfile.from_dict(
+                category,
+                profile_config.get(category, default_config),
+            )
+            for category in categories
+        }
+
+    def _to_document(self, item: object, category: str) -> RankingDocument:
+        """
+        Convert a domain object into the RankingDocument consumed by scorers.
+
+        :raises ValueError: If no adapter can handle the object/category combination.
+        """
+        for adapter in self.adapters:
+            if adapter.category == category and adapter.supports(item):
+                return adapter.to_document(item)
+
+        raise ValueError(
+            f"No ranking adapter found for category={category!r}, "
+            f"item_type={type(item).__name__!r}"
+        )

--- a/nfdi_search_engine/services/ranking/service.py
+++ b/nfdi_search_engine/services/ranking/service.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any
 
+from opentelemetry import trace
+
 from nfdi_search_engine.common.models.search_result import RankingInfo, SearchResult
+from nfdi_search_engine.infra.observability.decorators import traced
 from nfdi_search_engine.services.ranking.adapters import (
     ArticleRankingAdapter,
     AuthorRankingAdapter,
@@ -63,6 +67,14 @@ class RankingService:
         self.text_scorer = text_scorer or FieldWeightedTextScorer()
         self.feature_scorer = feature_scorer or FeatureScorer()
 
+    @traced(
+        "ranking_service.rank",
+        attrs=lambda self, query_text, category, results: {
+            "ranking.category": category,
+            "ranking.result_count": len(results),
+            "ranking.query_token_count": len(query_text.split()),
+        },
+    )
     def rank(
         self,
         query_text: str,
@@ -86,17 +98,27 @@ class RankingService:
         :rtype: list[SearchResult]
         """
         query = Query.from_string(query_text)
-        profile = self.profiles.get(category, RankingProfile.from_dict(category, {}))
+        profile = self.profiles.get(
+            category, RankingProfile.from_dict(category, {})
+        )
+        span = trace.get_current_span()
+        self._record_profile_attributes(span, profile)
 
         ranked = []
+        signal_totals: dict[str, float] = defaultdict(float)
         for result in results:
             doc = self._to_document(result.item, category)
             text_signals = self.text_scorer.score_details(query, doc, profile)
-            feature_signals = self.feature_scorer.score_details(query, doc, profile)
+            feature_signals = self.feature_scorer.score_details(
+                query, doc, profile
+            )
+            signals = {**text_signals, **feature_signals}
 
             text_score = sum(text_signals.values())
             feature_score = sum(feature_signals.values())
             total_score = text_score + feature_score
+            for signal, value in signals.items():
+                signal_totals[signal] += value
 
             if hasattr(doc.raw, "rankScore"):
                 doc.raw.rankScore = total_score
@@ -105,12 +127,15 @@ class RankingService:
                 score=total_score,
                 text_score=text_score,
                 feature_score=feature_score,
-                signals={**text_signals, **feature_signals},
+                signals=signals,
                 profile=profile.category,
             )
             ranked.append(result)
 
-        return sorted(ranked, key=lambda r: r.ranking.score, reverse=True)
+        ranked.sort(key=lambda r: r.ranking.score, reverse=True)
+        self._record_score_attributes(span, ranked, signal_totals)
+
+        return ranked
 
     def _profiles(
         self,
@@ -146,3 +171,57 @@ class RankingService:
             f"No ranking adapter found for category={category!r}, "
             f"item_type={type(item).__name__!r}"
         )
+
+    def _record_profile_attributes(self, span, profile: RankingProfile) -> None:
+        """Attach the active ranking parameters to the current ranking span."""
+        span.set_attribute("ranking.profile", profile.category)
+        span.set_attribute(
+            "ranking.profile.phrase_boost",
+            profile.phrase_boost
+        )
+        span.set_attribute(
+            "ranking.profile.exact_identifier_boost",
+            profile.exact_identifier_boost,
+        )
+
+        weights = {
+            "field": profile.field_weights,
+            "numeric": profile.numeric_feature_weights,
+            "boolean": profile.boolean_feature_weights,
+            "exact": profile.exact_field_boosts,
+        }
+        for weight_type, configured_weights in weights.items():
+            for name, value in configured_weights.items():
+                span.set_attribute(
+                    f"ranking.profile.{weight_type}.{name}",
+                    value,
+                )
+
+    def _record_score_attributes(
+        self,
+        span,
+        ranked: list[SearchResult],
+        signal_totals: dict[str, float],
+    ) -> None:
+        """Attach aggregate score metrics to the current ranking span."""
+        if not ranked:
+            return
+
+        count = len(ranked)
+        total_scores = [result.ranking.score for result in ranked]
+        text_scores = [result.ranking.text_score for result in ranked]
+        feature_scores = [result.ranking.feature_score for result in ranked]
+
+        for name, scores in (
+            ("total", total_scores),
+            ("text", text_scores),
+            ("feature", feature_scores),
+        ):
+            span.set_attribute(f"ranking.score.{name}.min", min(scores))
+            span.set_attribute(f"ranking.score.{name}.max", max(scores))
+            span.set_attribute(
+                f"ranking.score.{name}.avg", sum(scores) / count
+            )
+
+        for signal, total in signal_totals.items():
+            span.set_attribute(f"ranking.signal.{signal}.avg", total / count)

--- a/nfdi_search_engine/services/search_service.py
+++ b/nfdi_search_engine/services/search_service.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import importlib
 import traceback
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Tuple
-from rank_bm25 import BM25Plus
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+from nfdi_search_engine.common.models.search_result import SearchResult
 from nfdi_search_engine.common.models.search_settings import SearchSettings
 from nfdi_search_engine.services.deduplication import DeduplicationService
 from nfdi_search_engine.common.models.request_meta import RequestMeta
 from nfdi_search_engine.infra.store.result_store import ResultStore
 from nfdi_search_engine.services.chatbot_service import ChatbotService
+from nfdi_search_engine.services.ranking import RankingService
 from nfdi_search_engine.services.tracking_service import TrackingService
 
 
@@ -79,6 +80,7 @@ class SearchService:
         store: ResultStore,
         tracking: TrackingService,
         deduplication: DeduplicationService,
+        ranking: RankingService,
     ) -> None:
         """
         Initialize the search service.
@@ -97,6 +99,7 @@ class SearchService:
         self.store = store
         self.tracking = tracking
         self.deduplication = deduplication
+        self.ranking = ranking
 
     def run_search(self, ctx: SearchContext) -> SearchPage:
         """
@@ -127,22 +130,24 @@ class SearchService:
             if has_endpoint and src not in ctx.excluded_sources:
                 active_sources.append(src)
 
-        results_full, failed_sources = self._harvest(
+        raw_results, failed_sources = self._harvest(
             active_sources,
             ctx.search_term
         )
 
         # filter empty results per category
         for k in CATEGORIES:
-            results_full[k] = [r for r in results_full[k] if r is not None]
+            raw_results[k] = [r for r in raw_results[k] if r is not None]
 
         # deduplicate before ranking
-        results_full = self.deduplication.deduplicate(results_full)
+        results_full: Dict[str, List[SearchResult]] = self.deduplication.deduplicate(raw_results)
 
         # sort per category
         for k in CATEGORIES:
-            results_full[k] = self._sort_search_results(
-                ctx.search_term, results_full[k]
+            results_full[k] = self.ranking.rank(
+                ctx.search_term,
+                k,
+                results_full[k],
             )
 
         total_results = {k: len(v) for k, v in results_full.items()}
@@ -168,7 +173,8 @@ class SearchService:
 
         # first page slice
         page_results = {
-            k: results_full[k][: self.settings.first_page_n] for k in CATEGORIES
+            k: self._items(results_full[k][: self.settings.first_page_n])
+            for k in CATEGORIES
         }
 
         return SearchPage(
@@ -197,7 +203,7 @@ class SearchService:
         if rec is None:
             raise KeyError("search_id not found or expired")
 
-        results_full: Dict[str, List[Any]] = rec.results
+        results_full: Dict[str, List[SearchResult]] = rec.results
         meta = rec.meta
 
         total = int(meta["total_results"][ctx.object_type])
@@ -217,7 +223,7 @@ class SearchService:
             user_id=ctx.user_id,
         )
 
-        return chunk, new_displayed, total
+        return self._items(chunk), new_displayed, total
 
     def update_search_result_block(self, source: str, source_identifier: str, doi: str) -> Any:
         """
@@ -315,32 +321,6 @@ class SearchService:
 
         return results, failed
 
-    def _sort_search_results(self, search_term, search_results) -> list:
-        """
-        Rank and sort search results by textual relevance using BM25Plus.
-
-        This method tokenizes each result object's string representation and
-        computes BM25 scores relative to the tokenized query. The score is stored
-        on each result object as `rankScore`, and the list is sorted descending.
-
-        :param search_term: User query string.
-        :type search_term: str
-        :param search_results: List of result objects to score and sort.
-        :type search_results: List[Any]
-        :return: Sorted list of results in descending relevance.
-        :rtype: List[Any]
-        """
-        tokenized_results = [
-            str(result).lower().split(" ")
-            for result in search_results
-        ]
-        if len(tokenized_results) > 0:
-            bm25 = BM25Plus(tokenized_results)
-
-            tokenized_query = search_term.lower().split(" ")
-            doc_scores = bm25.get_scores(tokenized_query)
-
-            for idx, doc_score in enumerate(doc_scores):
-                search_results[idx].rankScore = doc_score
-
-        return sorted(search_results, key=lambda x: x.rankScore, reverse=True)
+    def _items(self, results: List[SearchResult]) -> List[Any]:
+        """Return domain objects for template compatibility."""
+        return [result.item if isinstance(result, SearchResult) else result for result in results]


### PR DESCRIPTION
Improves search result ranking and introduces `SearchResult` as the internal result container for ranking and provenance metadata.

- Added a dedicated `RankingService` for scoring and sorting deduplicated results.
- Added configurable ranking profiles in `Config.RANKING_PROFILES`.
- Added ranking adapters for publications, researchers/authors, projects, and generic schema-like objects.
- Added field-weighted text scoring and feature-based scoring.
- Added category-specific ranking signals, including exact identifier matches, exact title/name matches, citations, recency, researcher metrics, affiliations/research areas, and project funding/status metadata.
- Introduced `SearchResult` to wrap the merged domain object.
- Added ranking metadata via `SearchResult.ranking`, including total score, text score, feature score, and per-signal score details.
- Added provenance metadata via `SearchResult.provenance`, including source contributions, selected values, and merge strategy per field.
- Updated deduplication/search flow to store `SearchResult` objects internally while still returning domain objects to templates.
