### PR TITLE
Recommendation Engine Overhaul

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from nfdi_search_engine.services.analytics_service import AnalyticsService
 from nfdi_search_engine.services.publication_details_service import PublicationDetailsService, DetailsSettings
 from nfdi_search_engine.services.researcher_details_service import ResearcherDetailsService, OpenAISettings
 from nfdi_search_engine.services.resource_details_service import ResourceDetailsService
+from nfdi_search_engine.services.recommendation_service import RecommendationService, RecommendationSettings
 
 
 def create_app() -> Flask:
@@ -145,6 +146,11 @@ def create_app() -> Flask:
         tracking=tracking_service,
     )
 
+    recommendation_service = RecommendationService(
+        settings=RecommendationSettings.from_config(app.config),
+        tracking=tracking_service,
+    )
+
     # expose shared objects in app.extensions‚
     app.extensions["logger"] = logger
     app.extensions["result_store"] = result_store
@@ -160,6 +166,7 @@ def create_app() -> Flask:
         "publication_details": pub_details_service,
         "researcher_details": researcher_details_service,
         "resource_details": resource_details_service,
+        "recommendations": recommendation_service,
     }
 
     # register user loader

--- a/config.py
+++ b/config.py
@@ -167,6 +167,7 @@ class Config:
             "module": "openalex_publications",
             "search-endpoint": f"https://api.openalex.org/works?page=1&per-page={NUMBER_OF_RECORDS_FOR_SEARCH_ENDPOINT}&search=",
             "get-publication-endpoint": "https://api.openalex.org/works/",
+            "recommendations-endpoint": "https://api.openalex.org/works/",
             "get-researcher-publications-endpoint": "https://api.openalex.org/works?filter=author.id:",
         },
         "OPENALEX - Researchers": {

--- a/nfdi_search_engine/common/models/recommendation_settings.py
+++ b/nfdi_search_engine/common/models/recommendation_settings.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RecommendationSettings:
+    """
+    Settings for the recommendation service.
+
+    :param recommendation_sources: Map of {display_name: module_name} for every
+        source that exposes a non-empty ``recommendations-endpoint``.
+    :param limit: Maximum number of recommendations to request per source.
+    :param max_workers: Upper bound on threads used to fetch sources in parallel.
+    """
+    recommendation_sources: dict
+    limit: int = 100
+    max_workers: int = 16
+
+    @classmethod
+    def from_config(cls, cfg: dict) -> "RecommendationSettings":
+        recommendation_sources = {
+            name: source["module"]
+            for name, source in cfg["DATA_SOURCES"].items()
+            if str(source.get("recommendations-endpoint", "")).strip()
+            and source.get("module")
+        }
+        return cls(
+            recommendation_sources=recommendation_sources,
+            limit=int(cfg.get("RECOMMENDATION_LIMIT", 100)),
+            max_workers=int(cfg.get("RECOMMENDATION_MAX_WORKERS", 16)),
+        )

--- a/nfdi_search_engine/services/publication_details_service.py
+++ b/nfdi_search_engine/services/publication_details_service.py
@@ -23,7 +23,7 @@ class PublicationDetailsService:
     - DOI -> metadata resolution for batches
     - Publication details page harvesting across sources
     - Publication merging
-    - Publication citations/recommendations partial lists
+    - Publication citations partial lists
     - External DOI citation string formatting
     """
 
@@ -49,9 +49,6 @@ class PublicationDetailsService:
         }
         self.metadata_sources = {
             "OpenCitations": "opencitations",
-        }
-        self.recommendation_sources = {
-            "SEMANTIC SCHOLAR - Publications": "semanticscholar_publications",
         }
 
     def get_reference_dois(self, doi: str) -> List[str]:
@@ -309,39 +306,6 @@ class PublicationDetailsService:
             for pub in found:
                 if getattr(pub, "identifier", "") not in doi_list and (getattr(pub, "name", "") or "").lower() not in name_list:
                     publications.append(pub)
-
-        return publications
-
-    def get_recommendations_for_publication(self, doi: str) -> List[Article]:
-        """
-        Fetch recommended publications for a DOI from semantic scholar
-        Uses the .get_recommendations_for_publication() method from source modules.
-
-        :param doi: DOI to fetch recommendations for
-        :type doi: str
-        :return: List of recommended Articles
-        :rtype: List[Article]
-        """
-        doi = doi.lower()
-        publications: List[Article] = []
-
-        for source, module_name in self.citation_sources.items():
-            try:
-                mod = importlib.import_module(f"sources.{module_name}")
-                found = mod.get_recommendations_for_publication(
-                    doi=doi, tracking=self.tracking
-                ) or []
-            except Exception as e:
-                self.tracking.log_event_async(
-                    log_type="error",
-                    filename=f"sources/{module_name}.py",
-                    args=[source, doi],
-                    method=f"get_recommendations_for_publication",
-                    message=traceback.format_exception_only(e),
-                    traceback=traceback.format_exception(e),
-                )
-                continue
-            publications.extend(found)
 
         return publications
 

--- a/nfdi_search_engine/services/recommendation_service.py
+++ b/nfdi_search_engine/services/recommendation_service.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from itertools import zip_longest
+from typing import List, Optional, Tuple
+
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
+from nfdi_search_engine.common.models.objects import Article
+from nfdi_search_engine.common.models.recommendation_settings import RecommendationSettings
+from nfdi_search_engine.infra.observability.context import with_parent_context
+from nfdi_search_engine.infra.observability.decorators import traced, tracer
+from nfdi_search_engine.services.tracking_service import TrackingService
+
+# re-export so callers can import the service and its settings from one module
+# (parity with how DetailsSettings is imported alongside PublicationDetailsService)
+__all__ = ["RecommendationService", "RecommendationSettings"]
+
+
+class RecommendationService:
+    """
+    Service for publication recommendation retrieval.
+
+    Harvests recommended publications for a DOI across all configured
+    recommendation sources (currently Semantic Scholar and OpenAlex). Each
+    source module exposes a module-level ``get_recommendations_for_publication``
+    entrypoint that returns a list of :class:`Article` objects.
+    """
+
+    def __init__(self, settings: RecommendationSettings, tracking: TrackingService):
+        self.settings = settings
+        self.tracking = tracking
+
+    @traced(
+        "recommendation_service.get_recommendations_for_publication",
+        attrs=lambda self, doi: {
+            "recommendation.doi": doi,
+            "recommendation.source_count": len(self.settings.recommendation_sources),
+            "recommendation.limit": self.settings.limit,
+        },
+    )
+    def get_recommendations_for_publication(self, doi: str) -> List[Article]:
+        """
+        Fetch recommended publications for a DOI across recommendation sources.
+
+        Sources are harvested in parallel (see :meth:`_harvest`) and then merged
+        into a single ordered list (see :meth:`_merge`). The parent span records
+        the merged/deduplicated totals.
+
+        :param doi: DOI to fetch recommendations for
+        :type doi: str
+        :return: List of recommended Articles (deduplicated by DOI and title)
+        :rtype: List[Article]
+        """
+        doi = (doi or "").lower()
+
+        per_source = self._harvest(doi)
+        recommendations = self._merge(per_source)
+
+        fetched_count = sum(len(group) for group in per_source)
+        span = trace.get_current_span()
+        span.set_attribute("recommendation.contributing_source_count", len(per_source))
+        span.set_attribute("recommendation.fetched_count", fetched_count)
+        span.set_attribute("recommendation.result_count", len(recommendations))
+        span.set_attribute(
+            "recommendation.deduplicated_count", fetched_count - len(recommendations)
+        )
+
+        return recommendations
+
+    @traced(
+        "recommendation_service._harvest",
+        attrs=lambda self, doi: {
+            "recommendation.doi": doi,
+            "recommendation.source_count": len(self.settings.recommendation_sources),
+        },
+    )
+    def _harvest(self, doi: str) -> List[List[Article]]:
+        """
+        Fetch recommendations from every configured source in parallel.
+
+        Each source runs in its own thread and child span (carrying the source
+        name and result count), mirroring ``search_service._harvest``. Results are
+        collected by source and returned in configuration order - independent of
+        thread completion order - so the downstream merge stays deterministic.
+
+        :param doi: DOI to fetch recommendations for
+        :type doi: str
+        :return: One list of recommendations per contributing source, in config order
+        :rtype: List[List[Article]]
+        """
+        sources = self.settings.recommendation_sources
+
+        def fetch_source(source: str, module_name: str) -> Tuple[Optional[List[Article]], Optional[Exception]]:
+            with tracer.start_as_current_span(
+                "recommendation_service.fetch_source"
+            ) as span:
+                span.set_attribute("recommendation.source", source)
+                span.set_attribute("recommendation.module", module_name)
+                try:
+                    mod = importlib.import_module(f"sources.{module_name}")
+                    found = mod.get_recommendations_for_publication(
+                        doi=doi, tracking=self.tracking, limit=self.settings.limit
+                    ) or []
+                    span.set_attribute("recommendation.source_result_count", len(found))
+                    return found, None
+                except Exception as e:
+                    span.record_exception(e)
+                    span.set_status(Status(StatusCode.ERROR, str(e)))
+                    return None, e
+
+        results_by_source: dict[str, List[Article]] = {}
+        max_workers = min(self.settings.max_workers, len(sources) or 1)
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            # propagate the current trace context so per-source spans stay nested
+            fetch_with_ctx = with_parent_context(fetch_source)
+            futures = {
+                ex.submit(fetch_with_ctx, source, module_name): source
+                for source, module_name in sources.items()
+            }
+            for fut in as_completed(futures):
+                source = futures[fut]
+                found, err = fut.result()
+                if err is not None:
+                    self.tracking.log_event_async(
+                        log_type="error",
+                        filename=f"sources/{sources[source]}.py",
+                        args=[source, doi],
+                        method="get_recommendations_for_publication",
+                        message=traceback.format_exception_only(err),
+                        traceback=traceback.format_exception(err),
+                    )
+                    continue
+                if found:
+                    results_by_source[source] = found
+
+        # rebuild in configuration order (not completion order) so the merge is deterministic
+        return [results_by_source[s] for s in sources if s in results_by_source]
+
+    def _merge(self, per_source: List[List[Article]]) -> List[Article]:
+        """
+        Merge per-source recommendation lists into a single ordered list.
+
+        This is the one place result ordering is decided. Today it is a
+        round-robin interleave (1st of each source, then 2nd of each, ...) so
+        every source is represented near the top, with dedup by DOI and title -
+        the fairest merge available without a shared relevance score. When a
+        ranking engine is introduced, replace the interleave with a score-based
+        sort over the deduplicated set; the dedup below stays as-is.
+
+        :param per_source: One list of recommendations per source, in config order
+        :type per_source: List[List[Article]]
+        :return: Single deduplicated, ordered list of recommendations
+        :rtype: List[Article]
+        """
+        recommendations: List[Article] = []
+        seen_dois: set[str] = set()
+        seen_names: set[str] = set()
+        for rank in zip_longest(*per_source):
+            for pub in rank:
+                if pub is None:
+                    continue
+                pub_doi = (getattr(pub, "identifier", "") or "").lower()
+                pub_name = (getattr(pub, "name", "") or "").lower()
+                if pub_doi and pub_doi in seen_dois:
+                    continue
+                if pub_name and pub_name in seen_names:
+                    continue
+                if pub_doi:
+                    seen_dois.add(pub_doi)
+                if pub_name:
+                    seen_names.add(pub_name)
+                recommendations.append(pub)
+        return recommendations

--- a/nfdi_search_engine/web/details/publication_routes.py
+++ b/nfdi_search_engine/web/details/publication_routes.py
@@ -141,6 +141,7 @@ def publication_details_citations(doi):
 
 
 @bp.route("/publication-details-recommendations/<path:doi>", methods=["GET"])
+@limiter.limit("10 per minute")
 @timeit
 def publication_details_recommendations(doi):
     """
@@ -148,7 +149,7 @@ def publication_details_recommendations(doi):
     
     :param doi: The DOI string
     """
-    svc, _ = _get_services()
+    svc = current_app.extensions["services"]["recommendations"]
     pubs = svc.get_recommendations_for_publication(doi)
     return make_response(
         render_template(

--- a/sources/openalex_publications.py
+++ b/sources/openalex_publications.py
@@ -169,6 +169,50 @@ class OpenAlexPublications(BaseSource):
         if search_result:
             return self.map_hit(search_result)
 
+    def get_recommendations_for_publication(self, doi: str, limit: int = 100) -> List[Union[Article, CreativeWork]]:
+        """
+        Fetch recommendedations for a DOI via OpenAlex.
+
+        :param doi: DOI of the source publication.
+        :param limit: Maximum number of related works to resolve.
+        :return: Mapped publication objects for the related works.
+        """
+        works_base = Config.DATA_SOURCES[self.SOURCE].get("recommendations-endpoint", "")
+        if not works_base:
+            return []
+
+        # 1. resolve the DOI to its work and read the related_works ids
+        work = data_retriever.retrieve_object(
+            base_url=works_base,
+            identifier="https://doi.org/" + doi,
+        ) or {}
+        related = work.get("related_works", []) or []
+        if not related:
+            return []
+
+        # keep only the bare OpenAlex ids (e.g. "W123"), capped by limit
+        ids = [w.rsplit("/", 1)[-1] for w in related[:limit] if w]
+        if not ids:
+            return []
+
+        # 2. batch-fetch metadata for all related works in a single request
+        list_url = (
+            f"{works_base.rstrip('/')}"
+            f"?filter=ids.openalex:{'|'.join(ids)}&per-page={len(ids)}"
+        )
+        raw = data_retriever.retrieve_data(
+            base_url=works_base,
+            search_term="",
+            url=list_url,
+        ) or {}
+
+        recommendations: List[Union[Article, CreativeWork]] = []
+        for hit in self.extract_hits(raw):
+            publication = self.map_hit(hit)
+            if getattr(publication, "identifier", ""):
+                recommendations.append(publication)
+        return recommendations
+
 
 def search(search_term: str, results, tracking=None):
     """
@@ -188,3 +232,10 @@ def get_publication(doi: str, publications, tracking=None):
 
 def get_publications(url: str, results, tracking=None):
     OpenAlexPublications(tracking).get_publications(url, results)
+
+
+def get_recommendations_for_publication(doi: str, tracking=None, limit: int = 100) -> List[Union[Article, CreativeWork]]:
+    """
+    Entrypoint: fetch recommended publications for a DOI via OpenAlex related_works.
+    """
+    return OpenAlexPublications(tracking).get_recommendations_for_publication(doi, limit=limit)

--- a/sources/semanticscholar_publications.py
+++ b/sources/semanticscholar_publications.py
@@ -8,7 +8,9 @@ publication-details citations and recommendations. Integration points: get_dois_
 get_citations_for_publication, get_recommendations_for_publication.
 """
 import time
-from typing import Dict, Any, List
+from typing import Any, Callable, Dict, List
+
+import requests
 
 from config import Config
 from nfdi_search_engine.common.models.objects import thing, Article, Author
@@ -78,33 +80,54 @@ class SemanticScholarPublications:
         ]
         return [d for d in dois_citation if d]
 
-    def get_dois_recommendations(self, doi: str) -> List[str]:
+    def _request_with_retries(self, fetch: Callable[[], Any], context: str) -> Dict[str, Any]:
         """
-        Fetch the DOIs of recommendations for a given DOI.
+        Call ``fetch`` with retries, logging HTTP and parse errors.
 
-        Args:
-            source: Data source name (used for config lookup).
-            doi: The DOI of the article to fetch recommendations for.
+        Returns the response dict, or None if it never succeeds. Client errors
+        (4xx other than 429) are not retried, since retrying won't help and the
+        fixed back-off would otherwise block the request for MAX_RETRIES * delay.
 
-        Returns:
-            A list of DOIs of the recommended articles.
+        :param fetch: Zero-arg callable performing the HTTP request.
+        :param context: Human-readable label used in log messages.
         """
-        base_url = self._get_config(self.SOURCE, "recommendations-endpoint", "")
-        identifier = f"{doi}?fields=externalIds"
-        response = data_retriever.retrieve_object(
-            base_url=base_url,
-            identifier=identifier,
-            quote=False,
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = fetch()
+            except requests.HTTPError as e:
+                resp = e.response
+                status = resp.status_code if resp is not None else "?"
+                body = (resp.text[:300] if resp is not None else "").replace("\n", " ")
+                self.log_event(
+                    type="error",
+                    message=f"{self.SOURCE} - {context} - HTTP {status}: {body}",
+                )
+                if resp is not None and 400 <= resp.status_code < 500 and resp.status_code != 429:
+                    return None
+                time.sleep(RETRY_DELAY_SECONDS)
+                continue
+            except Exception as e:
+                self.log_event(
+                    type="error",
+                    message=f"{self.SOURCE} - {context} - request failed: {e!r}",
+                )
+                time.sleep(RETRY_DELAY_SECONDS)
+                continue
+
+            if isinstance(response, dict):
+                return response
+
+            self.log_event(
+                type="info",
+                message=f"{self.SOURCE} - {context} - retry {attempt + 1}/{MAX_RETRIES} (non-dict response)",
+            )
+            time.sleep(RETRY_DELAY_SECONDS)
+
+        self.log_event(
+            type="error",
+            message=f"{self.SOURCE} - {context} - gave up after {MAX_RETRIES} attempts",
         )
-
-        if not response or "recommendedPapers" not in response:
-            return []
-
-        dois_reference = [
-            ref.get("externalIds", {}).get("DOI", "")
-            for ref in response["recommendedPapers"]
-        ]
-        return [d for d in dois_reference if d]
+        return None
 
     def _fetch_paper_by_doi(self, doi: str) -> Dict[str, Any]:
         """
@@ -112,52 +135,43 @@ class SemanticScholarPublications:
         Returns the raw response dict or None on failure.
         """
         base_url = self._get_config(self.SOURCE, "citations-endpoint", "")
-        for attempt in range(MAX_RETRIES):
-            response = data_retriever.retrieve_object(
-                base_url=base_url,
-                identifier=doi,
-                quote=False,
-            )
-            if isinstance(response, dict):
-                return response
-            self.log_event(
-                type="info",
-                message=f"{self.SOURCE} - Retry {attempt + 1}/{MAX_RETRIES} for Semantic Scholar paper ID",
-            )
-            time.sleep(RETRY_DELAY_SECONDS)
-        return None
+        return self._request_with_retries(
+            lambda: data_retriever.retrieve_object(
+                base_url=base_url, identifier=doi, quote=False,
+            ),
+            context=f"resolve DOI->paperId ({doi})",
+        )
 
-    def _fetch_recommendations_by_paper_id(self, paper_id: str) -> Dict[str, Any]:
+    def _fetch_recommendations_by_paper_id(self, paper_id: str, limit: int = 100) -> Dict[str, Any]:
         """
         Retrieve recommendations for a paper by its Semantic Scholar paper ID (with retries).
         Returns the raw response dict or None on failure.
+
+        Note: the recommendations endpoint does not support nested author field
+        selection (e.g. ``authors.externalIds``), so ORCIDs are not available here.
         """
         base_url = self._get_config(self.SOURCE, "recommendations-endpoint", "")
-        search_term = f"{paper_id}?fields=title,publicationDate,externalIds&limit=10"
-        for attempt in range(MAX_RETRIES):
-            response = data_retriever.retrieve_data(
-                base_url=base_url,
-                search_term=search_term,
-            )
-            if isinstance(response, dict):
-                return response
-            self.log_event(
-                type="info",
-                message=f"{self.SOURCE} - Retry {attempt + 1}/{MAX_RETRIES} for recommendations",
-            )
-            time.sleep(RETRY_DELAY_SECONDS)
-        return None
+        fields = "title,publicationDate,externalIds,authors,isOpenAccess,openAccessPdf"
+        search_term = f"{paper_id}?fields={fields}&limit={limit}"
+        return self._request_with_retries(
+            lambda: data_retriever.retrieve_data(
+                base_url=base_url, search_term=search_term,
+            ),
+            context=f"recommendations (paper_id={paper_id}, limit={limit})",
+        )
 
-    def get_recommendations_for_publication(self, doi: str) -> List[Article]:
+    def get_recommendations_for_publication(self, doi: str, limit: int = 100) -> List[Article]:
         """
         Fetch recommended publications for a given DOI as Article objects.
 
         Resolves the DOI to a Semantic Scholar paper ID, then fetches recommendations.
-        Only articles with a non-empty DOI are included.
+        Only articles with a non-empty DOI are included. Each Article is populated
+        with authors, publication date, source, and (when available) an open-access
+        content URL so it can be rendered like a search result.
 
         Args:
-            source: Data source name (used for config lookup).
             doi: The DOI of the article.
+            limit: Maximum number of recommendations to request.
 
         Returns:
             List of Article objects for recommended publications.
@@ -177,11 +191,15 @@ class SemanticScholarPublications:
             message=f"{self.SOURCE} - Resolved DOI to Semantic Scholar paper_id: {paper_id}",
         )
 
-        rec_response = self._fetch_recommendations_by_paper_id(paper_id)
+        rec_response = self._fetch_recommendations_by_paper_id(paper_id, limit=limit)
         if not rec_response:
             return recommended_publications
 
         recommended_papers = rec_response.get("recommendedPapers", [])
+        self.log_event(
+            type="info",
+            message=f"{self.SOURCE} - received {len(recommended_papers)} recommendations for paper_id {paper_id}",
+        )
         for recommended_paper in recommended_papers:
             publication = Article()
             publication.name = remove_html_tags(
@@ -192,7 +210,25 @@ class SemanticScholarPublications:
             )
             publication.datePublished = recommended_paper.get(
                 "publicationDate", ""
-            )
+            ) or ""
+
+            for author in recommended_paper.get("authors", []) or []:
+                _author = Author()
+                _author.additionalType = "Person"
+                _author.name = author.get("name", "")
+                publication.author.append(_author)
+
+            open_access_pdf = recommended_paper.get("openAccessPdf") or {}
+            if recommended_paper.get("isOpenAccess") and open_access_pdf.get("url"):
+                publication.encoding_contentUrl = open_access_pdf.get("url", "")
+
+            _source = thing()
+            _source.name = self.SOURCE
+            rec_paper_id = recommended_paper.get("paperId", "")
+            if rec_paper_id:
+                _source.identifier = rec_paper_id
+                _source.url = f"https://www.semanticscholar.org/paper/{rec_paper_id}"
+            publication.source.append(_source)
 
             if publication.identifier:
                 recommended_publications.append(publication)
@@ -273,18 +309,11 @@ def get_dois_citations(doi: str, tracking=None) -> List[str]:
     return SemanticScholarPublications(tracking).get_dois_citations(doi)
 
 
-def get_dois_recommendations(doi: str, tracking=None) -> List[str]:
-    """
-    Entrypoint: fetch DOIs of recommendations for a given DOI.
-    """
-    return SemanticScholarPublications(tracking).get_dois_recommendations(doi)
-
-
-def get_recommendations_for_publication(doi: str, tracking=None) -> List[Article]:
+def get_recommendations_for_publication(doi: str, tracking=None, limit: int = 100) -> List[Article]:
     """
     Entrypoint: fetch recommended publications for a given DOI as Article objects.
     """
-    return SemanticScholarPublications(tracking).get_recommendations_for_publication(doi)
+    return SemanticScholarPublications(tracking).get_recommendations_for_publication(doi, limit=limit)
 
 
 def get_citations_for_publication(doi: str, tracking=None) -> List[Article]:

--- a/templates/partials/publication-details/recommendations.html
+++ b/templates/partials/publication-details/recommendations.html
@@ -1,21 +1,62 @@
+{% macro lock_icon(publication) %}
+{%- if publication.encoding_contentUrl -%}
+<img src="{{ url_for('static', filename='images/icons/open_lock.png') }}"
+    alt="open" style="height:0.6rem;position:relative;top:-1px;">
+{%- else -%}
+<img src="{{ url_for('static', filename='images/icons/closed_lock.png') }}"
+    alt="closed" style="height:0.6rem;position:relative;top:-1px;">
+{%- endif -%}
+{% endmacro %}
+
 {% for publication in publications %}
-<div class="card mb-2 p-2 rounded-extra shadow-bottom-right">
-    <div class="card-body">
-        <div class="d-flex bd-highlight fw-bold">
-            {{publication.name}}
+<div class="card mb-2 rec-card">
+    <div class="card-body p-2 fs-7">
+        <div class="mb-2">
+            {% if publication.identifier == '' %}
+            <span class="text-secondary fw-bold">{{ publication.name }}&nbsp;{{ lock_icon(publication) }}</span>
+            {% else %}
+            <a class="text-secondary fw-bold"
+                href="/publication-details/{{ publication | format_digital_obj_url('source-name','doi') }}"
+                target="_blank">{{ publication.name }}&nbsp;{{ lock_icon(publication) }}</a>
+            {% endif %}
         </div>
-        <div class="d-flex justify-content-between fs-7 pt-3">
-            <span class="">
-                <a class="text-decoration-none fw-bold" href='/publication-details/{{publication.identifier}}'
-                    target='_blank'>
-                    READ MORE ></a>
-            </span>
-            <span class="badge bg-pill">{{publication.datePublished}}</span>
+
+        {% if publication.author %}
+        {% set names = publication.author | map(attribute='name') | select | list %}
+        {% if names %}
+        <div class="authors mb-2 fs-7 text-secondary">
+            {{ names[:5] | join(', ') }}{% if names|length > 5 %} and {{ names|length - 5 }} more{% endif %}
+        </div>
+        {% endif %}
+        {% endif %}
+
+        <div class="d-flex flex-wrap gap-1 align-items-center">
+            {% if publication.identifier %}
+            <span class="badge bg-pill bg-secondary text-break" data-bs-toggle="tooltip"
+                data-bs-placement="top" title="DOI">{{ publication.identifier }}</span>
+            {% endif %}
+            {% if publication.datePublished %}
+            <span class="badge bg-pill bg-secondary" data-bs-toggle="tooltip"
+                data-bs-placement="top" title="Publication Date">{{ publication.datePublished }}</span>
+            {% endif %}
+            {% if publication.source and publication.source[0].name %}
+            {% set src = publication.source[0] %}
+            {% if src.url %}
+            <a class="text-decoration-none" href="{{ src.url }}" target="_blank">
+                <span class="badge bg-pill" data-bs-toggle="tooltip" data-bs-placement="top"
+                    title="Source">{{ src.name.split(' - ')[0] }}&nbsp;<i
+                        class="bi bi-box-arrow-up-right"></i></span>
+            </a>
+            {% else %}
+            <span class="badge bg-pill" data-bs-toggle="tooltip" data-bs-placement="top"
+                title="Source">{{ src.name.split(' - ')[0] }}</span>
+            {% endif %}
+            {% endif %}
         </div>
     </div>
 </div>
 {% endfor %}
 
 {% if publications|length == 0 %}
-No recommendations found
+<span class="text-secondary">No recommendations found</span>
 {% endif %}

--- a/templates/publication-details.html
+++ b/templates/publication-details.html
@@ -236,12 +236,12 @@
                     </div>
                 </div>
 
-                <div class="d-flex p-2 bd-highlight pt-4">
+                <div class="d-flex px-2 pt-4 pb-1 bd-highlight">
                     <span class="fw-bold fs-6">RECOMMENDATIONS <i class="bi bi-info-circle-fill text-secondary"
                             data-bs-toggle="tooltip" data-bs-placement="top"
-                            title="Retrieved from Semantic Scholar"></i></span>
+                            title="Retrieved from Semantic Scholar and OpenAlex"></i></span>
                 </div>
-                <div class="d-flex flex-column p-2 fs-6 border-bottom pb-4" id="recommendations_block">
+                <div class="d-flex flex-column px-2 pb-4 fs-6 border-bottom" id="recommendations_block">
                     <button type="button" class="btn btn-outline-secondary" id="btn-load-recommendations">Load</button>
                 </div>
 
@@ -467,7 +467,90 @@ document.addEventListener("DOMContentLoaded", () => {
             e.currentTarget.classList.add("d-none");
             render(keyCit, "citations_list", "btn-load-citations", false);
         });
-    
+
+    // (re)initialize bootstrap tooltips within a scope, skipping already-initialized ones
+    function reinitTooltips(scope) {
+        (scope || document).querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+            if (!bootstrap.Tooltip.getInstance(el)) new bootstrap.Tooltip(el);
+        });
+    }
+
+    // page-load tooltips (e.g. the RECOMMENDATIONS info icon)
+    reinitTooltips(document);
+
+    // paginate the injected recommendation cards: 10 per page with prev/next controls
+    function setupRecommendations(block) {
+        const cards = Array.from(block.querySelectorAll(".rec-card"));
+        const total = cards.length;
+        if (total === 0) return;
+
+        const pageSize = 10;
+        const pageCount = Math.ceil(total / pageSize);
+        let page = 0;
+
+        const bar = document.createElement("div");
+        bar.className = "d-flex justify-content-between align-items-center mb-2 fs-7";
+        const label = document.createElement("span");
+        label.className = "text-secondary";
+        const nav = document.createElement("div");
+        const prev = document.createElement("button");
+        prev.type = "button";
+        prev.className = "btn btn-sm btn-outline-secondary py-0 px-2 me-1";
+        prev.innerHTML = '<i class="bi bi-chevron-left"></i>';
+        const next = document.createElement("button");
+        next.type = "button";
+        next.className = "btn btn-sm btn-outline-secondary py-0 px-2";
+        next.innerHTML = '<i class="bi bi-chevron-right"></i>';
+        nav.append(prev, next);
+        bar.append(label, nav);
+        if (pageCount <= 1) nav.classList.add("d-none");
+        block.prepend(bar);
+
+        function render() {
+            const start = page * pageSize;
+            const end = Math.min(start + pageSize, total);
+            cards.forEach((c, i) => c.classList.toggle("d-none", i < start || i >= end));
+            label.textContent = `Showing ${start + 1}-${end} of ${total}`;
+            prev.disabled = page === 0;
+            next.disabled = page >= pageCount - 1;
+        }
+        // ctrl/cmd + click jumps to the first (prev) or last (next) page
+        prev.addEventListener("click", (ev) => {
+            if (page === 0) return;
+            page = (ev.ctrlKey || ev.metaKey) ? 0 : page - 1;
+            render();
+        });
+        next.addEventListener("click", (ev) => {
+            if (page >= pageCount - 1) return;
+            page = (ev.ctrlKey || ev.metaKey) ? pageCount - 1 : page + 1;
+            render();
+        });
+        render();
+    }
+
+    // recommendations: fetch the server-rendered partial on demand and inject it
+    document.getElementById("btn-load-recommendations")
+        ?.addEventListener("click", async (e) => {
+            const btn   = e.currentTarget;
+            const block = document.getElementById("recommendations_block");
+            btn.disabled = true;
+            btn.textContent = "Loading...";
+            try {
+                const res = await fetch(
+                    `/publication-details-recommendations/${encodeURIComponent(doiPage)}`,
+                    { method: "GET" }
+                );
+                if (!res.ok) throw new Error(`recommendations fetch failed (${res.status})`);
+                block.innerHTML = await res.text();
+                setupRecommendations(block);
+                reinitTooltips(block);
+            } catch (err) {
+                console.error(err);
+                btn.disabled = false;
+                btn.textContent = "Load";
+            }
+        });
+
     });
 
     document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
This PR refactors the recommendation system into a dedicated service similar to the rest of the project. Also, adds a second source (https://api.openalex.org/works), and updates the UI.

<img width="1144" height="780" alt="grafik" src="https://github.com/user-attachments/assets/0ef31597-3d5b-41f8-baa7-a8ffbd211919" />


- Extracted recommendations out of PublicationDetailsService into a dedicated RecommendationService + RecommendationSettings dataclass. The service discovers all sources with a recommendations-endpoint.
- Added OpenAlex as a second source (via related_works) alongside Semantic Scholar; results are merged via deduplication and a round-robin interleave
- We can also later add the [ranking algorithm](https://github.com/semantic-systems/nfdi-search-engine/pull/418) to rerank results
- Parallelized requests with a ThreadPoolExecutor + tracing
- Fixed an issue with the previously dead "Load" button.
- Updated the UI
- Client-side pagination