### PR TITLE
Dev Staging Environment

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,53 @@
+name: 'Deploy NFDI Search Engine (dev) on sems-kg-1'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: dev-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: [sems-kg-1-runner]
+    defaults:
+      run:
+        working-directory: dev
+    env:
+      COMPOSE_PROJECT_NAME: nfdi-search-engine-dev
+      COMPOSE_FILE: docker-compose.dev.yml
+    steps:
+      - name: 'Check out repo'
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          path: dev
+      - name: 'Stop the running dev NFDI Search Engine'
+        run: docker compose down
+      - name: 'Delete old dev Docker image'
+        run: docker image rm nfdi-search-engine-dev-search-engine || (echo "Image nfdi-search-engine-dev-search-engine didn't exist so not removed."; exit 0)
+      - name: 'Copy logging.conf'
+        run: cp logging.conf.example logging.conf
+      - name: 'Create .env'
+        run: |
+          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> ./.env
+          echo "IEEE_API_KEY=${{ secrets.IEEE_API_KEY }}" >> ./.env
+          echo "CLIENT_ID_GOOGLE=${{ secrets.CLIENT_ID_GOOGLE }}" >> ./.env
+          echo "CLIENT_SECRET_GOOGLE=${{ secrets.CLIENT_SECRET_GOOGLE }}" >> ./.env
+          echo "CLIENT_ID_GITHUB=${{ secrets.CLIENT_ID_GITHUB }}" >> ./.env
+          echo "CLIENT_SECRET_GITHUB=${{ secrets.CLIENT_SECRET_GITHUB }}" >> ./.env
+          echo "CLIENT_ID_ORCID=${{ secrets.CLIENT_ID_ORCID }}" >> ./.env
+          echo "CLIENT_SECRET_ORCID=${{ secrets.CLIENT_SECRET_ORCID }}" >> ./.env
+          echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> ./.env
+          echo "DASHBOARD_USERNAME=${{ secrets.DASHBOARD_USERNAME }}" >> ./.env
+          echo "DASHBOARD_PASSWORD=${{ secrets.DASHBOARD_PASSWORD }}" >> ./.env
+          echo "LLAMA3_USERNAME=${{ secrets.LLAMA3_USERNAME }}" >> ./.env
+          echo "LLAMA3_PASSWORD=${{ secrets.LLAMA3_PASSWORD }}" >> ./.env
+          echo "ELASTIC_SERVER=${{ secrets.ELASTIC_SERVER_DEV }}" >> ./.env     # Use the dev elastic server
+          echo "ELASTIC_USERNAME=${{ secrets.ELASTIC_USERNAME_DEV }}" >> ./.env
+          echo "ELASTIC_PASSWORD=${{ secrets.ELASTIC_PASSWORD_DEV }}" >> ./.env
+          echo "CHATBOT_SERVER=${{ secrets.CHATBOT_SERVER }}" >> ./.env
+      - name: 'Re-build Docker container from current source'
+        run: docker compose up --force-recreate --build --detach

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,33 +1,34 @@
 services:
-  search-engine:
-    ports:
-      - "6001:8000"
-    depends_on:
-      elastic:
-        condition: service_healthy
-      jaeger:
-        condition: service_healthy
+    search-engine:
+        build: .
+        ports:
+            - 127.0.0.1:6001:8000
+        restart: unless-stopped
+        depends_on:
+            jaeger:
+                condition: service_healthy
+        networks:
+            - nfdi-search-engine_default
 
-  jaeger:
-    depends_on:
-      elastic:
-        condition: service_healthy
-
-  elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    environment:
-      discovery.type: single-node
-      xpack.security.enabled: "false"
-      xpack.security.http.ssl.enabled: "false"
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s >/dev/null || exit 1"]
-      interval: 5s
-      timeout: 3s
-      retries: 30
-      start_period: 20s
-    restart: unless-stopped
-    networks:
-        - nfdi-search-engine_default
+    jaeger:
+        image: cr.jaegertracing.io/jaegertracing/jaeger:2.17.0
+        command: ["--config", "/etc/jaeger/config.yaml"]
+        volumes:
+            - ./jaeger-config.yaml:/etc/jaeger/config.yaml:ro
+        environment:
+            JAEGER_ES_SERVER_URLS: "${ELASTIC_SERVER}"
+            JAEGER_ES_USERNAME: "${ELASTIC_USERNAME}"
+            JAEGER_ES_PASSWORD: "${ELASTIC_PASSWORD}"
+        restart: unless-stopped
+        healthcheck:
+            test: ["CMD-SHELL", "wget -qO- http://localhost:13133/health/status >/dev/null || exit 1"]
+            interval: 10s
+            timeout: 3s
+            retries: 10
+        ports:
+            - 127.0.0.1:16687:16686
+        networks:
+            - nfdi-search-engine_default
+networks:
+    nfdi-search-engine_default:
+        external: false

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,33 @@
+services:
+  search-engine:
+    ports:
+      - "6001:8000"
+    depends_on:
+      elastic:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy
+
+  jaeger:
+    depends_on:
+      elastic:
+        condition: service_healthy
+
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+        - nfdi-search-engine_default


### PR DESCRIPTION
Adds a dockerfile and github workflow to deploy the develop branch. Notes:
- The staging environment is published on port 6001 which is mapped to [dev.nfdi-search.nliwod.org](dev.nfdi-search.nliwod.org)
- Renamed the previous `docker-compose.dev.yml` to `docker-compose.local.yml`, the new file `docker-compose.dev.yml` holds the information for the dev branch
- Added two new env variables to the github secrets (`ELASTIC_SERVER_DEV`, `ELASTIC_USERNAME_DEV`). `ELASTIC_PASSWORD_DEV `is empty and unused
- This uses the develop elastic server (`dev.nfdi-elastic.nliwod.org`)