### PR TITLE
Celery Integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import logging
 import logging.config
+import threading
 
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -17,7 +18,8 @@ from nfdi_search_engine.infra.elastic.indices import ensure_indices
 from nfdi_search_engine.infra.observability.init import init_tracing, TracingConfig
 from nfdi_search_engine.infra.store.in_memory_result_store import InMemoryTTLResultStore
 from nfdi_search_engine.infra.store.in_memory_kv_store import InMemoryTTLKVStore
-from nfdi_search_engine.infra.jobs.inprocess_dispatcher import InProcessDispatcher
+from nfdi_search_engine.infra.jobs.celery_app import celery_app, init_celery
+from nfdi_search_engine.infra.jobs.celery_dispatcher import CeleryDispatcher
 from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
 from nfdi_search_engine.infra.jobs.chatbot_processor import ChatbotProcessor
 from nfdi_search_engine.services.user_service import UserService
@@ -74,23 +76,18 @@ def create_app() -> Flask:
     )
     ensure_indices(es)
 
-    # background jobs‚
-    tracking_tasks = TrackingProcessor(es)
-    chatbot_tasks = ChatbotProcessor(
-        result_store=result_store,
-        settings=ChatbotSettings.from_config(app.config)
-    )
+    # background jobs
+    # the processors hold the job logic
+    # the Celery tasks in infra/jobs/tasks/ look them up here at run time (see init_celery)
+    processors = {
+        "tracking": TrackingProcessor(es),
+        "chatbot": ChatbotProcessor(
+            result_store=result_store,
+            settings=ChatbotSettings.from_config(app.config)
+        ),
+    }
 
-    jobs = InProcessDispatcher(
-        handlers={
-            "tracking.activity.write": tracking_tasks.handle_write_activity,
-            "tracking.search_term.write": tracking_tasks.handle_write_search_term,
-            "tracking.user_agent.upsert": tracking_tasks.handle_upsert_user_agent,
-            "tracking.event.write": tracking_tasks.handle_write_event,
-            "tracking.visitor_id.propagate": tracking_tasks.handle_propagate_visitor_id,
-            "chatbot.index_search_results": chatbot_tasks.handle_index_search_results,
-        }
-    )
+    jobs = CeleryDispatcher()
 
     # services
     user_service = UserService(
@@ -157,6 +154,7 @@ def create_app() -> Flask:
     app.extensions["result_store"] = result_store
     app.extensions["details_store"] = details_store
     app.extensions["job_dispatcher"] = jobs
+    app.extensions["processors"] = processors
     app.extensions["es_client"] = es
     app.extensions["services"] = {
         "search": search_service,
@@ -196,4 +194,27 @@ def create_app() -> Flask:
     app.register_blueprint(chatbot_bp)
     app.register_blueprint(details_bp)
 
+    # register the celery tasks, then run the worker in-process if the broker
+    # is the in-memory one (see Config.CELERY)
+    init_celery(app)
+    if app.config["CELERY"]["run_worker_in_process"]:
+        _start_worker_threads()
+
     return app
+
+
+def _start_worker_threads() -> None:
+    # pool="solo", concurrency=1 keeps jobs strictly ordered, which
+    # tracking.visitor_id.propagate depends on (see init_celery)
+    threading.Thread(
+        target=lambda: celery_app.Worker(
+            loglevel="WARNING", pool="solo", concurrency=1, quiet=True
+        ).start(),
+        daemon=True,
+        name="celery-worker",
+    ).start()
+    threading.Thread(
+        target=lambda: celery_app.Beat(loglevel="WARNING", quiet=True).run(),
+        daemon=True,
+        name="celery-beat",
+    ).start()

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import logging
 import logging.config
-import threading
 
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -18,7 +17,7 @@ from nfdi_search_engine.infra.elastic.indices import ensure_indices
 from nfdi_search_engine.infra.observability.init import init_tracing, TracingConfig
 from nfdi_search_engine.infra.store.in_memory_result_store import InMemoryTTLResultStore
 from nfdi_search_engine.infra.store.in_memory_kv_store import InMemoryTTLKVStore
-from nfdi_search_engine.infra.jobs.celery_app import celery_app, init_celery
+from nfdi_search_engine.infra.jobs.celery_app import init_celery
 from nfdi_search_engine.infra.jobs.celery_dispatcher import CeleryDispatcher
 from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
 from nfdi_search_engine.infra.jobs.chatbot_processor import ChatbotProcessor
@@ -194,27 +193,7 @@ def create_app() -> Flask:
     app.register_blueprint(chatbot_bp)
     app.register_blueprint(details_bp)
 
-    # register the celery tasks, then run the worker in-process if the broker
-    # is the in-memory one (see Config.CELERY)
+    # register the celery tasks; main.py starts the worker
     init_celery(app)
-    if app.config["CELERY"]["run_worker_in_process"]:
-        _start_worker_threads()
 
     return app
-
-
-def _start_worker_threads() -> None:
-    # pool="solo", concurrency=1 keeps jobs strictly ordered, which
-    # tracking.visitor_id.propagate depends on (see init_celery)
-    threading.Thread(
-        target=lambda: celery_app.Worker(
-            loglevel="WARNING", pool="solo", concurrency=1, quiet=True
-        ).start(),
-        daemon=True,
-        name="celery-worker",
-    ).start()
-    threading.Thread(
-        target=lambda: celery_app.Beat(loglevel="WARNING", quiet=True).run(),
-        daemon=True,
-        name="celery-beat",
-    ).start()

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from dotenv import find_dotenv, load_dotenv
 
 from typing import Optional
@@ -52,6 +53,10 @@ class Settings(BaseSettings):
     TRACING_SAMPLER_ARG: Optional[float] = None
     TRACING_INSTRUMENT_FLASK: bool = True
     TRACING_INSTRUMENT_REQUESTS: bool = True
+    TRACING_INSTRUMENT_CELERY: bool = True
+
+    # Celery. "memory://" runs the worker in-process; a real broker (redis://) does not.
+    CELERY_BROKER_URL: str = Field(default="memory://")
 
     model_config = SettingsConfigDict(env_file=find_dotenv(), env_file_encoding='utf-8', extra='ignore')
 
@@ -119,6 +124,9 @@ class Config:
         TRACING_SAMPLER_ARG = app_settings.TRACING_SAMPLER_ARG
         TRACING_INSTRUMENT_FLASK = app_settings.TRACING_INSTRUMENT_FLASK
         TRACING_INSTRUMENT_REQUESTS = app_settings.TRACING_INSTRUMENT_REQUESTS
+        TRACING_INSTRUMENT_CELERY = app_settings.TRACING_INSTRUMENT_CELERY
+
+        CELERY_BROKER_URL = app_settings.CELERY_BROKER_URL
 
     SESSION_PERMANENT = False
     SESSION_TYPE = "filesystem"
@@ -655,6 +663,29 @@ class Config:
                 "aliases": 10.0,
             },
         },
+    }
+
+    JOBS = {
+        # Jobs are registered by dropping a file into infra/jobs/tasks/. Listing one
+        # here additionally runs it on a timer. Example:
+        # "beat_schedule": {
+        #     "hello-world-every-10s": {
+        #         "task": "hello.world",
+        #         "schedule": 10.0,
+        #     }
+        # }
+        "beat_schedule": {},
+    }
+
+    CELERY = {
+        "broker_url": app_settings.CELERY_BROKER_URL,
+        "beat_schedule_filename": os.path.join(
+            tempfile.gettempdir(), "celerybeat-schedule"
+        ),
+        # The in-memory broker lives inside the process, so the web process runs the
+        # worker and beat itself. Keep gunicorn at one worker: a second one runs a
+        # second beat, firing every scheduled job twice.
+        "run_worker_in_process": app_settings.CELERY_BROKER_URL.startswith("memory://"),
     }
 
     ELASTIC = {

--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
 from app import create_app
+from nfdi_search_engine.infra.jobs.worker import start_worker_threads
 
 app = create_app()
+
+# must run at module level: gunicorn loads main:app and skips the __main__ block
+start_worker_threads(app)
 
 if __name__ == "__main__":
     app.run(
         host="0.0.0.0",
         port=5002,
         debug=True,
-        use_reloader=False  # the reloader would start a second celery beat, which would start every scheduled job twice
+        use_reloader=False  # the reloader would run a second beat, which would start every scheduled job twice
     )

--- a/main.py
+++ b/main.py
@@ -3,4 +3,9 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5002, debug=True)
+    app.run(
+        host="0.0.0.0",
+        port=5002,
+        debug=True,
+        use_reloader=False  # the reloader would start a second celery beat, which would start every scheduled job twice
+    )

--- a/nfdi_search_engine/infra/jobs/celery_app.py
+++ b/nfdi_search_engine/infra/jobs/celery_app.py
@@ -79,6 +79,7 @@ def init_celery(flask_app: "Flask") -> Celery:
         ", ".join(t for t in sorted(celery_app.tasks) if not t.startswith("celery.")),
     )
 
+    flask_app.extensions["celery"] = celery_app
     return celery_app
 
 

--- a/nfdi_search_engine/infra/jobs/celery_app.py
+++ b/nfdi_search_engine/infra/jobs/celery_app.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from typing import TYPE_CHECKING
+
+from celery import Celery
+from celery.signals import task_failure, task_prerun
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+log = logging.getLogger(__name__)
+
+# Every module in this package is imported at startup so its @celery_app.task
+# functions register themselves. Importing a module does not create a task, only
+# the decorator does, so shared helpers may live here as well.
+TASK_PACKAGE = "nfdi_search_engine.infra.jobs.tasks"
+
+celery_app = Celery("nfdi")
+
+
+def _discover_task_modules() -> list[str]:
+    """
+    Return every module in the task package.
+    """
+    pkg = importlib.import_module(TASK_PACKAGE)
+    return sorted(
+        module.name
+        for module in pkgutil.walk_packages(pkg.__path__, prefix=f"{TASK_PACKAGE}.")
+        if not module.name.rsplit(".", 1)[-1].startswith("_")
+    )
+
+
+def init_celery(flask_app: "Flask") -> Celery:
+    """
+    Configure the Celery app and register all task modules.
+
+    Tasks are plain module-level functions, so they cannot capture the objects
+    built in create_app(). Instead every task runs inside a Flask application
+    context and resolves its dependencies from ``current_app.extensions``, the
+    same way the web layer does.
+    """
+    cfg = flask_app.config["CELERY"]
+    jobs = flask_app.config["JOBS"]
+
+    class ContextTask(celery_app.Task):
+        def __call__(self, *args, **kwargs):
+            with flask_app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery_app.Task = ContextTask
+
+    modules = _discover_task_modules()
+
+    celery_app.conf.update(
+        broker_url=cfg["broker_url"],
+        task_serializer="json",
+        result_serializer="json",
+        accept_content=["json"],
+        # nothing reads job results, so the result backend is left unset
+        task_ignore_result=True,
+        worker_prefetch_multiplier=1,
+        timezone="UTC",
+        enable_utc=True,
+        beat_schedule=jobs["beat_schedule"],
+        beat_schedule_filename=cfg["beat_schedule_filename"],
+        include=modules,
+    )
+
+    # import eagerly, so a broken task module fails at startup instead of
+    # silently inside the worker thread
+    for module in modules:
+        importlib.import_module(module)
+
+    log.info(
+        "Registered jobs: %s",
+        ", ".join(t for t in sorted(celery_app.tasks) if not t.startswith("celery.")),
+    )
+
+    return celery_app
+
+
+@task_prerun.connect
+def _on_task_start(task_id=None, task=None, **kwargs):
+    log.info("Job started: %s (id=%s)", getattr(task, "name", "unknown"), task_id)
+
+
+@task_failure.connect
+def _on_task_failure(task_id=None, exception=None, sender=None, **kwargs):
+    log.error(
+        "Job failed: %s (id=%s): %r",
+        getattr(sender, "name", "unknown"), task_id, exception,
+    )

--- a/nfdi_search_engine/infra/jobs/celery_dispatcher.py
+++ b/nfdi_search_engine/infra/jobs/celery_dispatcher.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from kombu.exceptions import EncodeError
+
+from nfdi_search_engine.infra.jobs.celery_app import celery_app
+from nfdi_search_engine.infra.jobs.dispatcher import JobDispatcher
+
+log = logging.getLogger(__name__)
+
+
+class CeleryDispatcher(JobDispatcher):
+    """
+    Job dispatcher via Celery.
+
+    Jobs are published to the broker by task name, so callers never import the
+    task implementations. See nfdi_search_engine/infra/jobs/tasks/ for the
+    registered names.
+    """
+
+    def enqueue(self, name: str, payload: Dict[str, Any]) -> None:
+        try:
+            celery_app.send_task(name, args=[payload])
+        except EncodeError:
+            # Celery serializes the payload here, in the calling (request) thread.
+            # Enqueuing is fire-and-forget, so an unserializable payload must never
+            # escape into the request path.
+            log.exception("Job payload is not JSON-serializable, dropping job: %s", name)
+        except Exception:
+            log.exception("Failed to enqueue job: %s", name)

--- a/nfdi_search_engine/infra/jobs/inprocess_dispatcher.py
+++ b/nfdi_search_engine/infra/jobs/inprocess_dispatcher.py
@@ -12,7 +12,12 @@ log = logging.getLogger(__name__)
 
 class InProcessDispatcher(JobDispatcher):
     """
-    In-process background queue
+    In-process background queue.
+
+    OBSOLETE: no longer used in create_app(). All job dispatching now goes
+    through CeleryDispatcher (nfdi_search_engine/infra/jobs/celery_dispatcher.py),
+    which routes jobs to the Celery tasks in nfdi_search_engine/infra/jobs/tasks/.
+    Kept for reference only.
     """
 
     def __init__(self, handlers: Dict[str, Callable[[Dict[str, Any]], None]]) -> None:

--- a/nfdi_search_engine/infra/jobs/tasks/chatbot_tasks.py
+++ b/nfdi_search_engine/infra/jobs/tasks/chatbot_tasks.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from flask import current_app
+from requests.exceptions import RequestException
+
+from nfdi_search_engine.infra.jobs.celery_app import celery_app
+from nfdi_search_engine.infra.jobs.chatbot_processor import ChatbotProcessor
+
+
+def _processor() -> ChatbotProcessor:
+    return current_app.extensions["processors"]["chatbot"]
+
+
+@celery_app.task(
+    name="chatbot.index_search_results",
+    autoretry_for=(RequestException,),
+    retry_backoff=True,
+    retry_jitter=True,
+    max_retries=3,
+)
+def index_search_results(payload: dict) -> None:
+    _processor().handle_index_search_results(payload)

--- a/nfdi_search_engine/infra/jobs/tasks/tracking_tasks.py
+++ b/nfdi_search_engine/infra/jobs/tasks/tracking_tasks.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from elasticsearch import ConnectionError, ConnectionTimeout
+from flask import current_app
+
+from nfdi_search_engine.infra.jobs.celery_app import celery_app
+from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
+
+# Retry only on connection errors, where the request never reached Elasticsearch.
+# handle_upsert_user_agent reads before it writes, so retrying a call that did
+# reach the cluster could insert a duplicate.
+RETRY = {
+    "autoretry_for": (ConnectionError, ConnectionTimeout),
+    "retry_backoff": True,
+    "retry_jitter": True,
+    "max_retries": 3,
+}
+
+
+def _processor() -> TrackingProcessor:
+    return current_app.extensions["processors"]["tracking"]
+
+
+@celery_app.task(name="tracking.activity.write", **RETRY)
+def write_activity(doc: dict) -> None:
+    _processor().handle_write_activity(doc)
+
+
+@celery_app.task(name="tracking.search_term.write", **RETRY)
+def write_search_term(doc: dict) -> None:
+    _processor().handle_write_search_term(doc)
+
+
+@celery_app.task(name="tracking.event.write", **RETRY)
+def write_event(doc: dict) -> None:
+    _processor().handle_write_event(doc)
+
+
+@celery_app.task(name="tracking.user_agent.upsert", **RETRY)
+def upsert_user_agent(doc: dict) -> None:
+    _processor().handle_upsert_user_agent(doc)
+
+
+@celery_app.task(name="tracking.visitor_id.propagate", **RETRY)
+def propagate_visitor_id(payload: dict) -> None:
+    _processor().handle_propagate_visitor_id(payload)

--- a/nfdi_search_engine/infra/jobs/tasks/tracking_tasks.py
+++ b/nfdi_search_engine/infra/jobs/tasks/tracking_tasks.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from elasticsearch import ConnectionError, ConnectionTimeout
+from elasticsearch import ConnectionError
 from flask import current_app
 
 from nfdi_search_engine.infra.jobs.celery_app import celery_app
 from nfdi_search_engine.infra.jobs.tracking_processor import TrackingProcessor
 
-# Retry only on connection errors, where the request never reached Elasticsearch.
-# handle_upsert_user_agent reads before it writes, so retrying a call that did
-# reach the cluster could insert a duplicate.
+# Retry only on ConnectionError: the connection never opened, so nothing was sent and a retry cannot write twice
+# timeouts are not safe, because the write may have reached elastic
 RETRY = {
-    "autoretry_for": (ConnectionError, ConnectionTimeout),
+    "autoretry_for": (ConnectionError,),
     "retry_backoff": True,
     "retry_jitter": True,
-    "max_retries": 3,
+    "max_retries": 1, # the elastic client already retries, so one retry here is enough
 }
 
 
@@ -43,4 +42,6 @@ def upsert_user_agent(doc: dict) -> None:
 
 @celery_app.task(name="tracking.visitor_id.propagate", **RETRY)
 def propagate_visitor_id(payload: dict) -> None:
+    # this searches for the rows to patch, so it can miss recent writes that elastic has not made searchable yet
+    # running jobs in order does not change that
     _processor().handle_propagate_visitor_id(payload)

--- a/nfdi_search_engine/infra/jobs/worker.py
+++ b/nfdi_search_engine/infra/jobs/worker.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import threading
+
+from flask import Flask
+
+WORKER_THREAD_NAME = "celery-worker"
+
+
+def start_worker_threads(app: Flask) -> None:
+    """
+    Run the celery worker and beat as threads inside this process.
+
+    Does nothing when the broker is a real one (see Config.CELERY), or when the
+    threads are already running.
+    """
+    if not app.config["CELERY"]["run_worker_in_process"]:
+        return
+    if any(t.name == WORKER_THREAD_NAME for t in threading.enumerate()):
+        return
+
+    celery_app = app.extensions["celery"]
+
+    # pool="solo", concurrency=1 runs jobs one at a time, in the order they were queued
+    threading.Thread(
+        target=lambda: celery_app.Worker(
+            loglevel="WARNING", pool="solo", concurrency=1, quiet=True
+        ).start(),
+        daemon=True,
+        name=WORKER_THREAD_NAME,
+    ).start()
+    threading.Thread(
+        target=lambda: celery_app.Beat(loglevel="WARNING", quiet=True).run(),
+        daemon=True,
+        name="celery-beat",
+    ).start()

--- a/nfdi_search_engine/infra/observability/config.py
+++ b/nfdi_search_engine/infra/observability/config.py
@@ -35,6 +35,8 @@ class TracingConfig:
     :type instrument_flask: bool
     :param instrument_requests: Enable requests auto-instrumentation.
     :type instrument_requests: bool
+    :param instrument_celery: Enable Celery auto-instrumentation.
+    :type instrument_celery: bool
     """
     enabled: bool
     service_name: str = "nfdi-search-engine"
@@ -44,6 +46,7 @@ class TracingConfig:
     traces_sampler_arg: Optional[float] = None
     instrument_flask: bool = True
     instrument_requests: bool = True
+    instrument_celery: bool = True
 
     @classmethod
     def from_config(cls, cfg: Dict[str, Any]) -> "TracingConfig":
@@ -68,4 +71,5 @@ class TracingConfig:
                 "TRACING_INSTRUMENT_REQUESTS",
                 True
             )),
+            instrument_celery=bool(cfg.get("TRACING_INSTRUMENT_CELERY", True)),
         )

--- a/nfdi_search_engine/infra/observability/init.py
+++ b/nfdi_search_engine/infra/observability/init.py
@@ -56,4 +56,10 @@ def init_tracing(app, cfg: TracingConfig) -> None:
         from opentelemetry.instrumentation.requests import RequestsInstrumentor
         RequestsInstrumentor().instrument()
 
+    if cfg.instrument_celery:
+        # background jobs run after the request has returned, so their spans are
+        # linked to the enqueuing request through the broker message headers
+        from opentelemetry.instrumentation.celery import CeleryInstrumentor
+        CeleryInstrumentor().instrument()
+
     app._otel_initialized = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ opentelemetry-sdk==1.39.1
 opentelemetry-exporter-otlp==1.39.1
 opentelemetry-instrumentation-flask==0.60b1
 opentelemetry-instrumentation-requests==0.60b1
+opentelemetry-instrumentation-celery==0.60b1
+celery==5.6.3


### PR DESCRIPTION
This PR adds the [celery package](https://docs.celeryq.dev/en/stable/index.html) which replaces the existing job handler, and allows creating scheduled jobs. Notes:

- CeleryDispatcher replaces InProcessDispatcher, using the same JobDispatcher protocol
- Job implementations go in nfdi_search_engine/infra/jobs/tasks/ as individual Python files with a @celery_app.task decorated function and are automatically discovered
- To configure a scheduled job, see beat_schedule in config.py 
- Worker runs with pool=solo, concurrency=1 to keep jobs ordered 
- Jobs are traced in Jaeger as children of the request that enqueued them
- Jobs are saved in-memory, but we can switch to Redis via a config change (CELERY_BROKER_URL) 

One limitation: gunicorn has to stay at one worker, otherwise a second beat fires every scheduled job twice