### PR TITLE
Add field-level provenance for publication details

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,7 +120,14 @@ def create_app() -> Flask:
     deduplication_service = DeduplicationService(
         policies=default_policies(),
         mapping_preference=app.config.get("MAPPING_PREFERENCE", {}),
+        enable_provenance=bool(app.config["ENABLE_PROVENANCE"]),
     )
+    if app.config["ENABLE_PROVENANCE"]:
+        logger.info("Field-level provenance is ENABLED")
+    else:
+        logger.info(
+            "Field-level provenance is disabled (set ENABLE_PROVENANCE=false in .env to disable)"
+        )
 
     ranking_service = RankingService(
         categories=CATEGORIES,
@@ -139,6 +146,7 @@ def create_app() -> Flask:
     pub_details_service = PublicationDetailsService(
         settings=DetailsSettings.from_config(app.config),
         tracking=tracking_service,
+        merger=deduplication_service.merger,
     )
 
     researcher_details_service = ResearcherDetailsService(

--- a/config.py
+++ b/config.py
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
     TRACING_INSTRUMENT_FLASK: bool = True
     TRACING_INSTRUMENT_REQUESTS: bool = True
 
+    # Field-level merge provenance ({value, sources} per field in search results)
+    ENABLE_PROVENANCE: bool = True
+
     model_config = SettingsConfigDict(env_file=find_dotenv(), env_file_encoding='utf-8', extra='ignore')
 
 def validate_env():
@@ -119,6 +122,8 @@ class Config:
         TRACING_SAMPLER_ARG = app_settings.TRACING_SAMPLER_ARG
         TRACING_INSTRUMENT_FLASK = app_settings.TRACING_INSTRUMENT_FLASK
         TRACING_INSTRUMENT_REQUESTS = app_settings.TRACING_INSTRUMENT_REQUESTS
+
+        ENABLE_PROVENANCE = app_settings.ENABLE_PROVENANCE
 
     SESSION_PERMANENT = False
     SESSION_TYPE = "filesystem"

--- a/nfdi_search_engine/common/models/search_result.py
+++ b/nfdi_search_engine/common/models/search_result.py
@@ -18,6 +18,12 @@ class FieldProvenance:
     contributions: list[FieldContribution] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class FieldValueProvenance:
+    value: Any
+    sources: list[str] = field(default_factory=list)
+
+
 @dataclass
 class RankingInfo:
     score: float = 0.0
@@ -34,7 +40,140 @@ class SearchResult(Generic[T]):
     item: T
     sources: list[str] = field(default_factory=list)
     provenance: dict[str, FieldProvenance] = field(default_factory=dict)
+    field_provenance: dict[str, FieldValueProvenance] = field(default_factory=dict)
     ranking: RankingInfo = field(default_factory=RankingInfo)
 
     # for debugging
     source_items: list[Any] = field(default_factory=list, repr=False)
+
+    def item_dict(self, exclude_none: bool = True) -> dict[str, Any]:
+        """
+        Serialize the merged item for API output.
+
+        When field_provenance is populated, each covered field is emitted as
+        {"value": ..., "sources": [...]}; otherwise fields are returned as-is.
+        """
+        if hasattr(self.item, "model_dump"):
+            base = self.item.model_dump(mode="python", exclude_none=exclude_none)
+        else:
+            base = dict(vars(self.item))
+            if exclude_none:
+                base = {
+                    key: value
+                    for key, value in base.items()
+                    if value not in (None, "", [], {})
+                }
+
+        if not self.field_provenance:
+            return base
+
+        return {
+            field_name: (
+                {"value": fp.value, "sources": list(fp.sources)}
+                if (fp := self.field_provenance.get(field_name))
+                else value
+            )
+            for field_name, value in base.items()
+        }
+
+
+@dataclass
+class ProvenanceItemView(Generic[T]):
+    """
+    Template-facing wrapper around SearchResult.
+
+    Attribute access delegates to the merged domain item so existing templates
+    keep working; field-level sources are exposed via field_sources() / filters.
+    """
+
+    result: SearchResult[T]
+
+    @property
+    def search_result(self) -> SearchResult[T]:
+        return self.result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.result.item, name)
+
+    def field_sources(self, field_name: str) -> list[str]:
+        fp = self.result.field_provenance.get(field_name)
+        return list(fp.sources) if fp else []
+
+
+def resolve_search_result(obj: Any) -> SearchResult | None:
+    if isinstance(obj, ProvenanceItemView):
+        return obj.result
+    if isinstance(obj, SearchResult):
+        return obj
+    return None
+
+
+def field_sources_for(obj: Any, field_name: str) -> list[str]:
+    if isinstance(obj, ProvenanceItemView):
+        return obj.field_sources(field_name)
+    result = resolve_search_result(obj)
+    if result is None:
+        return []
+    fp = result.field_provenance.get(field_name)
+    return list(fp.sources) if fp else []
+
+
+@dataclass(frozen=True)
+class ProvenanceDisplayRow:
+    field: str
+    value: str
+    sources: str
+
+
+def format_provenance_value(value: Any, max_len: int = 120) -> str:
+    if value is None or value == "" or value == [] or value == {}:
+        return ""
+
+    if isinstance(value, list):
+        if not value:
+            return ""
+        if all(isinstance(item, str) for item in value):
+            text = ", ".join(value)
+        else:
+            return f"{len(value)} items"
+
+    elif isinstance(value, dict):
+        text = ", ".join(f"{key}: {val}" for key, val in list(value.items())[:3])
+    else:
+        text = getattr(value, "name", None) or str(value)
+
+    text = " ".join(str(text).split())
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def provenance_display_rows(
+    result: SearchResult,
+    *,
+    max_value_len: int = 120,
+) -> list[ProvenanceDisplayRow]:
+    rows: list[ProvenanceDisplayRow] = []
+    for field_name in sorted(result.field_provenance):
+        fp = result.field_provenance[field_name]
+        if not fp.sources:
+            continue
+        value = format_provenance_value(fp.value, max_len=max_value_len)
+        if not value:
+            continue
+        rows.append(
+            ProvenanceDisplayRow(
+                field=field_name,
+                value=value,
+                sources=", ".join(fp.sources),
+            )
+        )
+    return rows
+
+
+def unwrap_item(obj: Any) -> Any:
+    if isinstance(obj, ProvenanceItemView):
+        return obj.result.item
+    if isinstance(obj, SearchResult):
+        return obj.item
+    return obj

--- a/nfdi_search_engine/common/models/search_settings.py
+++ b/nfdi_search_engine/common/models/search_settings.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from config import Settings
+
 
 @dataclass(frozen=True)
 class SearchSettings:
@@ -9,6 +11,7 @@ class SearchSettings:
     first_page_n: int = 20
     lazy_load_n: int = 20
     results_ttl_s: int = 15 * 60  # 15 minutes
+    enable_provenance: bool = Settings.model_fields["ENABLE_PROVENANCE"].default
 
     @classmethod
     def from_config(cls, cfg: Dict[str, Any]) -> "SearchSettings":
@@ -20,4 +23,10 @@ class SearchSettings:
             lazy_load_n=int(
                 cfg.get("NUMBER_OF_RECORDS_TO_APPEND_ON_LAZY_LOAD", 20)),
             results_ttl_s=int(cfg.get("SEARCH_RESULTS_TTL_SECONDS", 15 * 60)),
+            enable_provenance=bool(
+                cfg.get(
+                    "ENABLE_PROVENANCE",
+                    Settings.model_fields["ENABLE_PROVENANCE"].default,
+                )
+            ),
         )

--- a/nfdi_search_engine/services/deduplication/merger.py
+++ b/nfdi_search_engine/services/deduplication/merger.py
@@ -5,6 +5,7 @@ from typing import Any
 from nfdi_search_engine.common.models.search_result import (
     FieldContribution,
     FieldProvenance,
+    FieldValueProvenance,
     SearchResult,
 )
 from nfdi_search_engine.services.deduplication.normalize import normalize_string
@@ -40,6 +41,21 @@ def _source_name(obj: Any) -> str | None:
     return names[0] if names else None
 
 
+def _sources_from_contributions(
+    group: list[Any],
+    field_prov_record: FieldProvenance,
+) -> list[str]:
+    seen: set[str] = set()
+    sources: list[str] = []
+    for contribution in field_prov_record.contributions:
+        for obj in group:
+            for name in _source_names(obj):
+                if name == contribution.source and name not in seen:
+                    seen.add(name)
+                    sources.append(name)
+    return sources
+
+
 def _preference_index(obj: Any, field: str, mapping_preference: dict) -> float:
     """
     Helper to get the preference index of an object's field value based on its source.
@@ -63,18 +79,27 @@ class ObjectMerger:
     When category is provided it returns a SearchResult with provenance metadata for search-result storage/ranking.
     """
 
+    def __init__(self, enable_provenance: bool = False) -> None:
+        self.enable_provenance = enable_provenance
+
     def merge(
         self,
         group: list[Any],
         mapping_preference: dict,
         category: str | None = None,
         entity_key: str = "",
+        enable_provenance: bool | None = None,
     ) -> Any:
         """
         Merge a list of result objects into one.
         Returns a SearchResult if a category if provided, the domain object otherwise.
         Applies strategies from mapping_preference and adds the provenance record.
         """
+        use_provenance = (
+            self.enable_provenance
+            if enable_provenance is None
+            else enable_provenance
+        )
         source_items = self._source_items(group)
         if not source_items:
             log.warning("ObjectMerger.merge() called with an empty list")
@@ -88,6 +113,7 @@ class ObjectMerger:
         ))
         merged = target_cls()
         provenance = {}
+        field_level_provenance: dict[str, FieldValueProvenance] = {}
 
         # iterate through all fields of the target class
         for field in type(merged).model_fields:
@@ -98,11 +124,11 @@ class ObjectMerger:
 
             # build the merged value for this field based on the strategy
             if strategy == "max":
-                value, field_provenance = self._value_max(group, field)
+                value, field_prov_record = self._value_max(group, field)
             elif strategy == "union":
-                value, field_provenance = self._value_union(group, field)
+                value, field_prov_record = self._value_union(group, field)
             else:
-                value, field_provenance = self._value_preference(
+                value, field_prov_record = self._value_preference(
                     group,
                     field,
                     mapping_preference
@@ -116,8 +142,14 @@ class ObjectMerger:
                     log.warning(
                         "Could not set field %r on %s during merge, skipping", field, target_cls.__name__)
 
-            if field_provenance.contributions:
-                provenance[field] = field_provenance
+            if field_prov_record.contributions:
+                provenance[field] = field_prov_record
+
+            if use_provenance and not _is_empty(value):
+                field_level_provenance[field] = FieldValueProvenance(
+                    value=value,
+                    sources=_sources_from_contributions(group, field_prov_record),
+                )
 
         if category is None:
             return merged
@@ -128,6 +160,7 @@ class ObjectMerger:
             item=merged,
             sources=self._sources(source_items),
             provenance=provenance,
+            field_provenance=field_level_provenance if use_provenance else {},
             source_items=source_items,
         )
 

--- a/nfdi_search_engine/services/deduplication/service.py
+++ b/nfdi_search_engine/services/deduplication/service.py
@@ -19,10 +19,15 @@ class DeduplicationService:
     duplicate objects merged according to the policies (see `nfdi_search_engine/services/deduplication/policies`).
     """
 
-    def __init__(self, policies: list[DedupPolicy], mapping_preference: dict) -> None:
+    def __init__(
+        self,
+        policies: list[DedupPolicy],
+        mapping_preference: dict,
+        enable_provenance: bool = False,
+    ) -> None:
         self.policies = policies
         self.mapping_preference = mapping_preference
-        self.merger = ObjectMerger()
+        self.merger = ObjectMerger(enable_provenance=enable_provenance)
 
     @traced(
         "deduplication_service.deduplicate",

--- a/nfdi_search_engine/services/publication_details_service.py
+++ b/nfdi_search_engine/services/publication_details_service.py
@@ -9,6 +9,13 @@ import requests
 
 from nfdi_search_engine.common.models.objects import Article
 from nfdi_search_engine.common.models.details_settings import DetailsSettings
+from nfdi_search_engine.common.models.search_result import (
+    ProvenanceDisplayRow,
+    SearchResult,
+)
+from nfdi_search_engine.services.publication_provenance_display import (
+    publication_provenance_display_rows,
+)
 from nfdi_search_engine.services.tracking_service import TrackingService
 from nfdi_search_engine.services.deduplication.merger import ObjectMerger
 from nfdi_search_engine.infra.observability.decorators import traced
@@ -31,12 +38,13 @@ class PublicationDetailsService:
         self,
         settings: DetailsSettings,
         tracking: TrackingService,
+        merger: ObjectMerger,
         http: Optional[requests.Session] = None,
     ):
         self.settings = settings
         self.tracking = tracking
+        self.merger = merger
         self.http = http or requests.Session()
-        self.merger = ObjectMerger()
 
         # we can think about moving this to the config
         self.references_sources = {
@@ -257,18 +265,34 @@ class PublicationDetailsService:
 
         return publications, failed
 
-    def merge_publications(self, publications: List[Any]) -> Any:
+    def merge_publications(
+        self, publications: List[Any]
+    ) -> tuple[Any, list[ProvenanceDisplayRow]]:
         """
         Merge multiple publication objects into a single publication representation.
 
+        When provenance is enabled, also returns display rows for the details page.
+
         :param publications: List of publication-like objects
         :type publications: List[Any]
-        :return: Single object with merged fields
-        :rtype: Any
+        :return: Merged publication item and optional provenance rows
+        :rtype: tuple[Any, list[ProvenanceDisplayRow]]
         """
         if not publications:
-            return None
-        return self.merger.merge(publications, self.settings.mapping_preference["publications"])
+            return None, []
+
+        pref = self.settings.mapping_preference["publications"]
+        if self.merger.enable_provenance:
+            merged = self.merger.merge(
+                publications,
+                pref,
+                category="publications",
+            )
+            if isinstance(merged, SearchResult):
+                return merged.item, publication_provenance_display_rows(merged)
+            return merged, []
+
+        return self.merger.merge(publications, pref), []
 
     def get_citations_for_publication(self, doi: str) -> List[Article]:
         """

--- a/nfdi_search_engine/services/publication_provenance_display.py
+++ b/nfdi_search_engine/services/publication_provenance_display.py
@@ -1,0 +1,238 @@
+"""Publication details page provenance presentation (display layer only)."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from nfdi_search_engine.common.models.search_result import (
+    ProvenanceDisplayRow,
+    SearchResult,
+)
+
+# Ordered display configuration: internal field name -> user-facing label.
+PUBLICATION_PROVENANCE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("name", "Title"),
+    ("author", "Authors"),
+    ("abstract", "Abstract"),
+    ("keywords", "Keywords"),
+    ("identifier", "DOI"),
+    ("datePublished", "Publication date"),
+    ("publication", "Publisher"),
+    ("license", "License"),
+    ("referenceCount", "References"),
+    ("citationCount", "Citations"),
+)
+
+PUBLICATION_PROVENANCE_HIDDEN_FIELDS = frozenset(
+    {
+        "additionalType",
+        "description",
+        "originalSource",
+        "partiallyLoaded",
+        "rankScore",
+        "source",
+        "url",
+    }
+)
+
+_LICENSE_LABEL_PATTERNS = (
+    re.compile(
+        r"Creative Commons\s+CC0\s+[\d.]+\s+Universal",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"CC\s*BY(?:\s*[-\s]?\s*NC|\s*[-\s]?\s*SA|\s*[-\s]?\s*ND)*\s*[\d.]+",
+        re.IGNORECASE,
+    ),
+    re.compile(r"CC0\s*[\d.]+", re.IGNORECASE),
+)
+
+
+def _truncate(text: str, max_len: int) -> str:
+    text = " ".join(str(text).split())
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def _format_authors(value: Any, *, max_len: int, max_names: int = 3) -> str:
+    if not isinstance(value, list) or not value:
+        return ""
+
+    names: list[str] = []
+    for author in value:
+        name = getattr(author, "name", None) or ""
+        name = str(name).strip()
+        if name:
+            names.append(name)
+
+    if names:
+        preview = ", ".join(names[:max_names])
+        if len(names) > max_names:
+            preview = f"{preview}, …"
+        return _truncate(preview, max_len)
+
+    return f"{len(value)} authors"
+
+
+def _format_publication_date(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    normalized = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+        return f"{parsed.day} {parsed.strftime('%b %Y')}"
+    except ValueError:
+        pass
+
+    if len(text) >= 10 and text[4] == "-" and text[7] == "-":
+        try:
+            parsed = datetime.strptime(text[:10], "%Y-%m-%d")
+            return f"{parsed.day} {parsed.strftime('%b %Y')}"
+        except ValueError:
+            pass
+
+    return text
+
+
+def _format_count(value: Any, unit: str) -> str:
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    try:
+        count = int(float(text))
+    except (TypeError, ValueError):
+        lowered = text.lower()
+        if lowered.endswith(unit):
+            return text
+        return text
+
+    return f"{count} {unit}"
+
+
+def _extract_license_label(text: str) -> str | None:
+    for pattern in _LICENSE_LABEL_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return " ".join(match.group(0).split())
+    return None
+
+
+def _format_license_from_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if "creativecommons.org" not in parsed.netloc or not segments:
+        return None
+
+    if len(segments) >= 3 and segments[0] == "publicdomain" and segments[1] == "zero":
+        return f"Creative Commons CC0 {segments[2]} Universal"
+
+    if len(segments) >= 3 and segments[0] == "licenses":
+        license_type = segments[1].upper().replace("-", " ")
+        version = segments[2]
+        if license_type == "BY":
+            return f"CC BY {version}"
+        return f"CC {license_type} {version}".strip()
+
+    if len(segments) >= 2:
+        return " ".join(segments[-2:]).replace("-", " ").title()
+
+    return None
+
+
+def _format_license(value: Any, *, max_len: int) -> str:
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    label: str | None = None
+    if text.startswith(("http://", "https://")):
+        label = _format_license_from_url(text)
+    else:
+        label = _extract_license_label(text)
+
+    if label:
+        return _truncate(label, max_len)
+
+    return _truncate(text, max_len)
+
+
+def _format_default(value: Any, *, max_len: int) -> str:
+    if value is None or value == "" or value == [] or value == {}:
+        return ""
+
+    if isinstance(value, list):
+        if all(isinstance(item, str) for item in value):
+            return _truncate(", ".join(value), max_len)
+        return ""
+
+    if isinstance(value, dict):
+        return _truncate(
+            ", ".join(f"{key}: {val}" for key, val in list(value.items())[:3]),
+            max_len,
+        )
+
+    return _truncate(getattr(value, "name", None) or str(value), max_len)
+
+
+def _format_publication_provenance_value(
+    field_name: str,
+    value: Any,
+    max_len: int,
+) -> str:
+    if field_name == "author":
+        return _format_authors(value, max_len=max_len)
+    if field_name == "datePublished":
+        return _format_publication_date(value)
+    if field_name == "referenceCount":
+        return _format_count(value, "references")
+    if field_name == "citationCount":
+        return _format_count(value, "citations")
+    if field_name == "license":
+        return _format_license(value, max_len=max_len)
+    return _format_default(value, max_len=max_len)
+
+
+def publication_provenance_display_rows(
+    result: SearchResult,
+    *,
+    max_value_len: int = 120,
+) -> list[ProvenanceDisplayRow]:
+    """
+    Build curated provenance rows for the publication details modal.
+
+    Reads only from SearchResult.field_provenance; does not generate provenance.
+    """
+    rows: list[ProvenanceDisplayRow] = []
+
+    for field_name, label in PUBLICATION_PROVENANCE_FIELDS:
+        if field_name in PUBLICATION_PROVENANCE_HIDDEN_FIELDS:
+            continue
+
+        fp = result.field_provenance.get(field_name)
+        if fp is None or not fp.sources:
+            continue
+
+        value = _format_publication_provenance_value(
+            field_name,
+            fp.value,
+            max_value_len,
+        )
+        if not value:
+            continue
+
+        rows.append(
+            ProvenanceDisplayRow(
+                field=label,
+                value=value,
+                sources=", ".join(fp.sources),
+            )
+        )
+
+    return rows

--- a/nfdi_search_engine/web/details/publication_routes.py
+++ b/nfdi_search_engine/web/details/publication_routes.py
@@ -120,8 +120,14 @@ def publication_details(source_name, doi, ts):
     if not publications:
         return make_response(render_template("no-results.html", type="publication", identifier=doi))
 
-    merged = pub_svc.merge_publications(publications)
-    return make_response(render_template("publication-details.html", publication=merged))
+    merged, provenance_rows = pub_svc.merge_publications(publications)
+    return make_response(
+        render_template(
+            "publication-details.html",
+            publication=merged,
+            provenance_rows=provenance_rows,
+        )
+    )
 
 
 @bp.route("/publication-details-citations/<path:doi>", methods=["GET"])

--- a/templates/partials/publication-details/provenance-modal.html
+++ b/templates/partials/publication-details/provenance-modal.html
@@ -1,0 +1,34 @@
+{% macro provenanceModal(modal_id, provenance_rows) %}
+<div id="{{ modal_id }}" class="modal fade" tabindex="-1" aria-labelledby="{{ modal_id }}-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="{{ modal_id }}-label">Field Provenance</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="table-responsive">
+                    <table class="table table-sm table-striped align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th scope="col">Field</th>
+                                <th scope="col">Value</th>
+                                <th scope="col">Source</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in provenance_rows %}
+                            <tr>
+                                <td class="text-nowrap">{{ row.field }}</td>
+                                <td>{{ row.value }}</td>
+                                <td>{{ row.sources }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endmacro %}

--- a/templates/publication-details.html
+++ b/templates/publication-details.html
@@ -13,6 +13,8 @@
 
 {% block content %}
 
+{% from 'partials/publication-details/provenance-modal.html' import provenanceModal %}
+
 <!-- ### main content ### -->
 <main class=''>
     <div id='mainContent' class="container">
@@ -245,6 +247,20 @@
                     <button type="button" class="btn btn-outline-secondary" id="btn-load-recommendations">Load</button>
                 </div>
 
+                {% if provenance_rows %}
+                <div class="d-flex p-2 bd-highlight pt-4">
+                    <span class="fw-bold fs-6">PROVENANCE <i class="bi bi-info-circle-fill text-secondary"
+                            data-bs-toggle="tooltip" data-bs-placement="top"
+                            title="Shows which data sources contributed each merged field"></i></span>
+                </div>
+                <div class="d-flex flex-column p-2 fs-6 border-bottom pb-4" id="provenance_block">
+                    <button type="button" class="btn btn-outline-secondary" id="btn-view-provenance"
+                        data-bs-toggle="modal" data-bs-target="#publication-provenance-modal">
+                        View
+                    </button>
+                </div>
+                {% endif %}
+
                 <!-- 
                 <div class=" d-flex p-2 bd-highlight pt-4">
                     <span class="fw-bold fs-6">FAIR ASSESSMENT</span>
@@ -278,6 +294,10 @@
 
     </div>
 </main>
+
+{% if provenance_rows %}
+{{ provenanceModal('publication-provenance-modal', provenance_rows) }}
+{% endif %}
 
 {% endblock content %}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("opentelemetry", MagicMock())
+sys.modules.setdefault("opentelemetry.trace", MagicMock())

--- a/tests/test_merger_field_provenance.py
+++ b/tests/test_merger_field_provenance.py
@@ -1,0 +1,151 @@
+from nfdi_search_engine.common.models.objects import Article, thing
+from nfdi_search_engine.common.models.search_result import SearchResult
+from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+
+PUBLICATION_PREF = {
+    "__default__": [
+        "CROSSREF - Publications",
+        "OPENALEX - Publications",
+    ],
+    "citationCount": "max",
+    "keywords": "union",
+}
+
+
+def _source(name: str) -> thing:
+    return thing(name=name)
+
+
+def _article(
+    *,
+    name: str = "",
+    abstract: str = "",
+    citation_count: str = "",
+    keywords: list[str] | None = None,
+    source_name: str = "",
+) -> Article:
+    article = Article(
+        name=name,
+        abstract=abstract,
+        citationCount=citation_count,
+        keywords=keywords or [],
+        source=[_source(source_name)] if source_name else [],
+    )
+    return article
+
+
+class TestObjectMergerFieldProvenance:
+    def test_disabled_mode_matches_plain_merge(self):
+        merger = ObjectMerger(enable_provenance=False)
+        group = [
+            _article(name="Paper A", abstract="From Crossref", source_name="CROSSREF - Publications"),
+            _article(name="Paper A", abstract="From OpenAlex", source_name="OPENALEX - Publications"),
+        ]
+
+        result = merger.merge(group, PUBLICATION_PREF, category="publications")
+
+        assert isinstance(result, SearchResult)
+        assert result.item.name == "Paper A"
+        assert result.item.abstract == "From Crossref"
+        assert result.field_provenance == {}
+        assert result.item_dict() == result.item.model_dump(mode="python", exclude_none=True)
+
+    def test_multi_source_merge_wraps_fields_with_sources(self):
+        merger = ObjectMerger(enable_provenance=True)
+        group = [
+            _article(
+                name="Paper A",
+                abstract="Crossref abstract",
+                citation_count="10",
+                keywords=["nlp"],
+                source_name="CROSSREF - Publications",
+            ),
+            _article(
+                name="Paper A",
+                abstract="OpenAlex abstract",
+                citation_count="25",
+                keywords=["semantics"],
+                source_name="OPENALEX - Publications",
+            ),
+        ]
+
+        result = merger.merge(group, PUBLICATION_PREF, category="publications")
+        payload = result.item_dict()
+
+        assert payload["name"] == {
+            "value": "Paper A",
+            "sources": ["CROSSREF - Publications", "OPENALEX - Publications"],
+        }
+        assert payload["abstract"] == {
+            "value": "Crossref abstract",
+            "sources": ["CROSSREF - Publications", "OPENALEX - Publications"],
+        }
+        assert payload["citationCount"] == {
+            "value": "25",
+            "sources": ["CROSSREF - Publications", "OPENALEX - Publications"],
+        }
+        assert payload["keywords"] == {
+            "value": ["nlp", "semantics"],
+            "sources": ["CROSSREF - Publications", "OPENALEX - Publications"],
+        }
+        assert result.item.name == "Paper A"
+        assert result.item.citationCount == "25"
+
+    def test_single_source_merge_still_emits_source_list(self):
+        merger = ObjectMerger(enable_provenance=True)
+        article = _article(
+            name="Solo Paper",
+            abstract="Only one source",
+            source_name="OPENALEX - Publications",
+        )
+
+        result = merger.merge([article], PUBLICATION_PREF, category="publications")
+        payload = result.item_dict()
+
+        assert payload["name"] == {
+            "value": "Solo Paper",
+            "sources": ["OPENALEX - Publications"],
+        }
+        assert payload["abstract"] == {
+            "value": "Only one source",
+            "sources": ["OPENALEX - Publications"],
+        }
+
+    def test_missing_source_metadata_uses_empty_sources(self):
+        merger = ObjectMerger(enable_provenance=True)
+        article = Article(name="No Source Metadata", abstract="Plain object")
+
+        result = merger.merge([article], PUBLICATION_PREF, category="publications")
+        payload = result.item_dict()
+
+        assert payload["name"]["value"] == "No Source Metadata"
+        assert payload["name"]["sources"] == []
+        assert payload["abstract"]["value"] == "Plain object"
+        assert payload["abstract"]["sources"] == []
+
+    def test_merge_without_category_returns_plain_domain_object(self):
+        merger = ObjectMerger(enable_provenance=True)
+        group = [
+            _article(name="Paper A", source_name="CROSSREF - Publications"),
+            _article(name="Paper A", source_name="OPENALEX - Publications"),
+        ]
+
+        merged = merger.merge(group, PUBLICATION_PREF)
+
+        assert isinstance(merged, Article)
+        assert not isinstance(merged, SearchResult)
+        assert merged.name == "Paper A"
+
+    def test_per_merge_flag_overrides_constructor_default(self):
+        merger = ObjectMerger(enable_provenance=False)
+        article = _article(name="Flag Test", source_name="OPENALEX - Publications")
+
+        result = merger.merge(
+            [article],
+            PUBLICATION_PREF,
+            category="publications",
+            enable_provenance=True,
+        )
+
+        assert result.field_provenance
+        assert result.item_dict()["name"]["sources"] == ["OPENALEX - Publications"]

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -1,0 +1,143 @@
+"""Integration tests for field-level provenance through dedup and search."""
+
+from nfdi_search_engine.common.models.objects import Article, thing
+from nfdi_search_engine.common.models.search_result import SearchResult
+from nfdi_search_engine.common.models.search_settings import SearchSettings
+from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+from nfdi_search_engine.services.deduplication.policies import default_policies
+from nfdi_search_engine.services.deduplication.service import DeduplicationService
+from nfdi_search_engine.services.search_service import SearchService
+
+
+PUBLICATION_PREF = {
+    "publications": {
+        "__default__": [
+            "CROSSREF - Publications",
+            "OPENALEX - Publications",
+            "OPENAIRE - Products",
+        ],
+        "citationCount": "max",
+        "keywords": "union",
+    },
+}
+
+
+def _source(name: str, doi: str = "10.5555/x") -> thing:
+    return thing(name=name, identifier=doi, url=f"https://doi.org/{doi}")
+
+
+def _article(
+    *,
+    name: str,
+    source_name: str,
+    doi: str = "10.5555/merged",
+    description: str = "Test abstract",
+) -> Article:
+    return Article(
+        name=name,
+        identifier=doi,
+        description=description,
+        source=[_source(source_name, doi)],
+    )
+
+
+class DummyService:
+    pass
+
+
+def _search_service(enable_provenance: bool) -> SearchService:
+    dedup = DeduplicationService(
+        default_policies(),
+        PUBLICATION_PREF,
+        enable_provenance=enable_provenance,
+    )
+    settings = SearchSettings(data_sources={}, enable_provenance=enable_provenance)
+    return SearchService(
+        settings,
+        DummyService(),
+        DummyService(),
+        DummyService(),
+        dedup,
+        DummyService(),
+    )
+
+
+class TestProvenanceIntegration:
+    def test_config_flag_enables_merger_and_search_service(self):
+        svc = _search_service(enable_provenance=True)
+        assert svc.deduplication.merger.enable_provenance is True
+        assert svc.settings.enable_provenance is True
+
+    def test_deduplication_populates_field_provenance_for_merged_publications(self):
+        dedup = DeduplicationService(
+            default_policies(),
+            PUBLICATION_PREF,
+            enable_provenance=True,
+        )
+        raw = {
+            "publications": [
+                _article(
+                    name="Shared Title",
+                    source_name="CROSSREF - Publications",
+                ),
+                _article(
+                    name="Shared Title",
+                    source_name="OPENALEX - Publications",
+                ),
+            ],
+            "researchers": [],
+            "resources": [],
+            "organizations": [],
+            "events": [],
+            "projects": [],
+            "others": [],
+        }
+
+        results = dedup.deduplicate(raw)
+        assert len(results["publications"]) == 1
+
+        merged = results["publications"][0]
+        assert isinstance(merged, SearchResult)
+        assert merged.field_provenance["name"].value == "Shared Title"
+        assert merged.field_provenance["name"].sources == [
+            "CROSSREF - Publications",
+            "OPENALEX - Publications",
+        ]
+
+    def test_search_service_items_returns_plain_domain_objects(self):
+        svc = _search_service(enable_provenance=True)
+        result = ObjectMerger(enable_provenance=True).merge(
+            [
+                _article(name="Paper", source_name="OPENALEX - Publications"),
+            ],
+            PUBLICATION_PREF["publications"],
+            category="publications",
+        )
+
+        items = svc._items([result])
+        assert items[0].__class__.__name__ == "Article"
+
+    def test_item_dict_serializes_field_provenance(self):
+        dedup = DeduplicationService(
+            default_policies(),
+            PUBLICATION_PREF,
+            enable_provenance=True,
+        )
+        raw = {
+            "publications": [
+                _article(name="Paper", source_name="CROSSREF - Publications", doi="10.5555/a"),
+                _article(name="Paper", source_name="OPENALEX - Publications", doi="10.5555/a"),
+            ],
+            "researchers": [],
+            "resources": [],
+            "organizations": [],
+            "events": [],
+            "projects": [],
+            "others": [],
+        }
+        merged = dedup.deduplicate(raw)["publications"][0]
+
+        assert merged.item_dict()["name"] == {
+            "value": "Paper",
+            "sources": ["CROSSREF - Publications", "OPENALEX - Publications"],
+        }

--- a/tests/test_publication_details_provenance.py
+++ b/tests/test_publication_details_provenance.py
@@ -1,0 +1,68 @@
+"""Legacy publication details provenance service tests."""
+
+from nfdi_search_engine.common.models.objects import Article, thing
+from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+from nfdi_search_engine.services.publication_details_service import PublicationDetailsService
+from nfdi_search_engine.common.models.details_settings import DetailsSettings
+
+
+PUBLICATION_PREF = {
+    "publications": {
+        "__default__": [
+            "CROSSREF - Publications",
+            "OPENALEX - Publications",
+        ],
+        "citationCount": "max",
+        "keywords": "union",
+    },
+}
+
+
+def _article(*, name: str, source_name: str, doi: str = "10.5555/merged") -> Article:
+    return Article(
+        name=name,
+        identifier=doi,
+        description=f"Abstract for {name}",
+        keywords=["AI", "NLP"],
+        source=[thing(name=source_name, identifier=doi, url=f"https://doi.org/{doi}")],
+    )
+
+
+class DummyTracking:
+    def log_event_async(self, **kwargs):
+        return None
+
+
+def _details_service(merger: ObjectMerger) -> PublicationDetailsService:
+    return PublicationDetailsService(
+        settings=DetailsSettings(
+            data_sources={},
+            mapping_preference=PUBLICATION_PREF,
+        ),
+        tracking=DummyTracking(),
+        merger=merger,
+    )
+
+
+class TestPublicationDetailsProvenance:
+    def test_merge_publications_uses_injected_shared_merger(self):
+        merger = ObjectMerger(enable_provenance=True)
+        svc = _details_service(merger)
+        assert svc.merger is merger
+
+    def test_merge_publications_returns_empty_rows_when_disabled(self):
+        svc = _details_service(ObjectMerger(enable_provenance=False))
+        publication, rows = svc.merge_publications(
+            [
+                _article(name="Paper", source_name="CROSSREF - Publications"),
+                _article(name="Paper", source_name="OPENALEX - Publications"),
+            ]
+        )
+        assert isinstance(publication, Article)
+        assert rows == []
+
+    def test_merge_publications_handles_missing_publications(self):
+        svc = _details_service(ObjectMerger(enable_provenance=True))
+        publication, rows = svc.merge_publications([])
+        assert publication is None
+        assert rows == []

--- a/tests/test_publication_details_provenance_ui.py
+++ b/tests/test_publication_details_provenance_ui.py
@@ -1,0 +1,70 @@
+"""Template tests for publication details provenance modal."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("opentelemetry", MagicMock())
+sys.modules.setdefault("opentelemetry.trace", MagicMock())
+
+from flask import Flask
+
+from nfdi_search_engine.common.models.search_result import ProvenanceDisplayRow
+from nfdi_search_engine.web.filters import register_filters
+
+TEMPLATES = str(Path(__file__).resolve().parents[1] / "templates")
+
+
+class TestPublicationDetailsProvenanceTemplate:
+    def test_provenance_modal_renders_table_rows(self):
+        app = Flask(__name__, template_folder=TEMPLATES)
+        register_filters(app)
+
+        template = app.jinja_env.from_string(
+            "{% from 'partials/publication-details/provenance-modal.html' import provenanceModal %}"
+            "{% if provenance_rows %}"
+            "<div id='provenance_block'>"
+            "<button id='btn-view-provenance' data-bs-toggle='modal' "
+            "data-bs-target='#publication-provenance-modal'>View</button>"
+            "</div>"
+            "{{ provenanceModal('publication-provenance-modal', provenance_rows) }}"
+            "{% endif %}"
+        )
+        rows = [
+            ProvenanceDisplayRow(
+                field="Title",
+                value="Machine Learning Approaches",
+                sources="OPENALEX - Publications, CROSSREF - Publications",
+            ),
+            ProvenanceDisplayRow(
+                field="Keywords",
+                value="AI, NLP",
+                sources="OPENALEX - Publications",
+            ),
+        ]
+
+        with app.app_context():
+            html = template.render(provenance_rows=rows)
+
+        assert "provenance_block" in html
+        assert "btn-view-provenance" in html
+        assert "publication-provenance-modal" in html
+        assert "Machine Learning Approaches" in html
+        assert "OPENALEX - Publications, CROSSREF - Publications" in html
+        assert "AI, NLP" in html
+
+    def test_provenance_section_hidden_when_rows_missing(self):
+        app = Flask(__name__, template_folder=TEMPLATES)
+        template = app.jinja_env.from_string(
+            "{% from 'partials/publication-details/provenance-modal.html' import provenanceModal %}"
+            "{% if provenance_rows %}"
+            "<div id='provenance_block'></div>"
+            "{{ provenanceModal('publication-provenance-modal', provenance_rows) }}"
+            "{% endif %}"
+        )
+
+        with app.app_context():
+            html = template.render(provenance_rows=[])
+
+        assert 'id="provenance_block"' not in html
+        assert 'id="publication-provenance-modal"' not in html

--- a/tests/test_publication_provenance_display.py
+++ b/tests/test_publication_provenance_display.py
@@ -1,0 +1,256 @@
+"""Tests for publication provenance display configuration and formatting."""
+
+from nfdi_search_engine.common.models.objects import Article, Author, thing
+from nfdi_search_engine.common.models.search_result import (
+    FieldValueProvenance,
+    SearchResult,
+)
+from nfdi_search_engine.services.deduplication.merger import ObjectMerger
+from nfdi_search_engine.services.publication_provenance_display import (
+    publication_provenance_display_rows,
+)
+
+
+PUBLICATION_PREF = {
+    "__default__": ["CROSSREF - Publications", "OPENALEX - Publications"],
+    "citationCount": "max",
+    "referenceCount": "max",
+    "keywords": "union",
+}
+
+
+def _search_result(field_provenance: dict[str, FieldValueProvenance]) -> SearchResult:
+    return SearchResult(
+        category="publications",
+        entity_key="publications:test",
+        item=Article(name="Example"),
+        field_provenance=field_provenance,
+    )
+
+
+class TestPublicationProvenanceDisplay:
+    def test_rows_follow_configured_order_and_labels(self):
+        result = _search_result(
+            {
+                "keywords": FieldValueProvenance(
+                    value=["AI", "NLP"],
+                    sources=["OPENALEX - Publications"],
+                ),
+                "name": FieldValueProvenance(
+                    value="Example Paper",
+                    sources=["CROSSREF - Publications"],
+                ),
+                "rankScore": FieldValueProvenance(
+                    value=1.5,
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+
+        assert [row.field for row in rows] == ["Title", "Keywords"]
+        assert rows[0].value == "Example Paper"
+        assert rows[1].value == "AI, NLP"
+
+    def test_hidden_internal_fields_are_not_shown(self):
+        result = _search_result(
+            {
+                "description": FieldValueProvenance(
+                    value="Duplicate abstract",
+                    sources=["OPENALEX - Publications"],
+                ),
+                "originalSource": FieldValueProvenance(
+                    value="Crossref",
+                    sources=["CROSSREF - Publications"],
+                ),
+                "source": FieldValueProvenance(
+                    value=[thing(name="OPENALEX - Publications")],
+                    sources=["OPENALEX - Publications"],
+                ),
+                "url": FieldValueProvenance(
+                    value="https://example.org/paper",
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        assert publication_provenance_display_rows(result) == []
+
+    def test_authors_show_names_when_available(self):
+        result = _search_result(
+            {
+                "author": FieldValueProvenance(
+                    value=[
+                        Author(name="Ada Lovelace"),
+                        Author(name="Grace Hopper"),
+                        Author(name="Alan Turing"),
+                        Author(name="Extra Author"),
+                    ],
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].field == "Authors"
+        assert rows[0].value == "Ada Lovelace, Grace Hopper, Alan Turing, …"
+
+    def test_authors_fallback_to_count_without_names(self):
+        result = _search_result(
+            {
+                "author": FieldValueProvenance(
+                    value=[Author(name=""), Author(name="")],
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].value == "2 authors"
+
+    def test_publication_date_is_human_friendly(self):
+        result = _search_result(
+            {
+                "datePublished": FieldValueProvenance(
+                    value="2020-08-01T04:18:32Z",
+                    sources=["CROSSREF - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].field == "Publication date"
+        assert rows[0].value == "1 Aug 2020"
+
+    def test_reference_and_citation_counts_include_units(self):
+        result = _search_result(
+            {
+                "referenceCount": FieldValueProvenance(
+                    value="42",
+                    sources=["CROSSREF - Publications"],
+                ),
+                "citationCount": FieldValueProvenance(
+                    value="25",
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = {row.field: row.value for row in publication_provenance_display_rows(result)}
+        assert rows["References"] == "42 references"
+        assert rows["Citations"] == "25 citations"
+
+    def test_license_prefers_readable_label_for_urls(self):
+        result = _search_result(
+            {
+                "license": FieldValueProvenance(
+                    value="https://creativecommons.org/licenses/by/4.0/",
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].value == "CC BY 4.0"
+
+    def test_license_extracts_short_label_from_long_descriptive_text(self):
+        long_text = (
+            "Alle im GESIS DBK veröffentlichten Metadaten sind frei verfügbar unter der "
+            "Creative Commons CC0 1.0 Universal Public Domain Dedication. GESIS bittet "
+            "jedoch darum, die Nutzung der Metadaten in Publikationen zu dokumentieren."
+        )
+        result = _search_result(
+            {
+                "license": FieldValueProvenance(
+                    value=long_text,
+                    sources=["GESIS KG"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].value == "Creative Commons CC0 1.0 Universal"
+
+    def test_license_truncates_unrecognized_long_text(self):
+        long_text = "x" * 200
+        result = _search_result(
+            {
+                "license": FieldValueProvenance(
+                    value=long_text,
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert len(rows[0].value) == 120
+        assert rows[0].value.endswith("...")
+
+    def test_abstract_is_truncated(self):
+        result = _search_result(
+            {
+                "abstract": FieldValueProvenance(
+                    value="word " * 80,
+                    sources=["OPENALEX - Publications"],
+                ),
+            }
+        )
+
+        rows = publication_provenance_display_rows(result)
+        assert rows[0].field == "Abstract"
+        assert len(rows[0].value) == 120
+        assert rows[0].value.endswith("...")
+
+    def test_config_covers_expected_publication_fields(self):
+        from nfdi_search_engine.services.publication_provenance_display import (
+            PUBLICATION_PROVENANCE_FIELDS,
+        )
+
+        configured_fields = [field_name for field_name, _ in PUBLICATION_PROVENANCE_FIELDS]
+        assert configured_fields == [
+            "name",
+            "author",
+            "abstract",
+            "keywords",
+            "identifier",
+            "datePublished",
+            "publication",
+            "license",
+            "referenceCount",
+            "citationCount",
+        ]
+
+
+class TestPublicationDetailsProvenanceIntegration:
+    def test_merge_publications_uses_display_rows(self):
+        from nfdi_search_engine.services.publication_details_service import (
+            PublicationDetailsService,
+        )
+        from nfdi_search_engine.common.models.details_settings import DetailsSettings
+
+        class DummyTracking:
+            def log_event_async(self, **kwargs):
+                return None
+
+        merger = ObjectMerger(enable_provenance=True)
+        svc = PublicationDetailsService(
+            settings=DetailsSettings(
+                data_sources={},
+                mapping_preference={"publications": PUBLICATION_PREF},
+            ),
+            tracking=DummyTracking(),
+            merger=merger,
+        )
+
+        article = Article(
+            name="Paper",
+            identifier="10.5555/x",
+            abstract="An abstract",
+            source=[thing(name="OPENALEX - Publications")],
+        )
+        publication, rows = svc.merge_publications([article])
+
+        assert publication.name == "Paper"
+        assert rows
+        assert rows[0].field == "Title"


### PR DESCRIPTION

Add field-level provenance support for merged publications and expose source
information through the publication details page.

## Changes
- Added optional field-level provenance tracking during merge
- Added provenance information to SearchResult
- Added provenance modal on publication details with curated fields and formatting
- Kept provenance generation in ObjectMerger and presentation logic separate
- Added tests for provenance generation and details-page display


## Testing
`PYTHONPATH=. python -m pytest tests/ -k provenance -q`

All provenance tests passing.
